### PR TITLE
Needed to run the installdependencies service

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -19,5 +19,6 @@ command -v docker-compose >/dev/null 2>&1 || {
 }
 
 docker pull golang:latest
+docker-compose run --rm installdependencies
 docker-compose build
 docker-compose run --rm package


### PR DESCRIPTION
`lc bootstrap` will call an `installdependencies` service, but `./bootstrap` was not.