### PR TITLE
add blackbox test for teardown of networks with -f

### DIFF
--- a/blackbox-test/features/teardown.feature
+++ b/blackbox-test/features/teardown.feature
@@ -73,12 +73,16 @@ Feature: teardown task
     Then it should succeed
     When I run `docker network ls`
     Then the output should contain 'elsy_teardown_lc_bbt_network_test'
+    When I run `lc teardown`
+    Then it should succeed
+    When I run `docker network ls`
+    Then the output should contain 'elsy_teardown_lc_bbt_network_test'
     When I run `lc teardown -f`
     Then it should succeed
     When I run `docker network ls`
     Then the output should not contain 'elsy_teardown_lc_bbt_network_test'
 
-  Scenario: with v2 volumes
+  Scenario: with v2 volumes and -f flag
     Given a file named "docker-compose.yml" with:
     """yaml
     version: '2'
@@ -96,6 +100,10 @@ Feature: teardown task
     When I run `lc test`
     Then it should succeed
     When I run `docker volume ls -q`
+    Then the output should contain 'teardown_test_build_cache'
+    When I run `lc teardown`
+    Then it should succeed
+    And I run `docker volume ls -q`
     Then the output should contain 'teardown_test_build_cache'
     When I run `lc teardown -f`
     Then it should succeed

--- a/blackbox-test/features/teardown.feature
+++ b/blackbox-test/features/teardown.feature
@@ -54,6 +54,30 @@ Feature: teardown task
     And I run `lc dc ps`
     Then the output should not contain 'teardowntestcontainer'
 
+  Scenario: with v2 networks and -f flag
+    Given a file named "docker-compose.yml" with:
+    """yaml
+    version: '2'
+
+    services:
+      test:
+        image: busybox
+        command: "/bin/true"
+        networks:
+          - elsy_teardown_lc_bbt_network_test
+
+    networks:
+      elsy_teardown_lc_bbt_network_test:
+    """
+    When I run `lc test`
+    Then it should succeed
+    When I run `docker network ls`
+    Then the output should contain 'elsy_teardown_lc_bbt_network_test'
+    When I run `lc teardown -f`
+    Then it should succeed
+    When I run `docker network ls`
+    Then the output should not contain 'elsy_teardown_lc_bbt_network_test'
+
   Scenario: with v2 volumes
     Given a file named "docker-compose.yml" with:
     """yaml


### PR DESCRIPTION
Relates to #5.

Compose does not offer a clean way to remove only networks; the only way to really remove them is to use `down`, but that would also remove our containers with the gc label. Compose also doesn't label networks (though hopefully it will soon: https://github.com/docker/compose/issues/3107) so we can't do the same type of thing we are doing for containers in `./command/teardown.go#removeContainersWithoutGcLabel`.

So until Compose offers a better way of finding/removing the networks it creates, just clarify the behavior in the blackbox-test (i.e., they are removed during `lc teardown -f`).