### PR TITLE
Initial Support for Compose v2 Syntax with Templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## _Unreleased_
 
+- Add initial support for Compose v2 syntax when using templates [\#11](https://github.com/cisco/elsy/pull/11)
+
 ## v1.2.1
 
 - fixing release issue with 1.2.0 (`./VERSION`) did not get updated.

--- a/blackbox-test/features/lein.feature
+++ b/blackbox-test/features/lein.feature
@@ -64,3 +64,60 @@ Feature: Leiningen template
       | 0 failures, 0 errors.                              |
     And the following folders should not be empty:
     | target/classes           |
+
+  Scenario: standard Leiningen project with compose v2 file
+    Given a file named "project.clj" with:
+    """
+    (defproject foo "0.1.0-SNAPSHOT"
+      :license {:name "Eclipse Public License"
+                :url "http://www.eclipse.org/legal/epl-v10.html"}
+      :dependencies [[org.clojure/clojure "1.8.0"]]
+      :main ^:skip-aot foo.core
+      :target-path "target/%s"
+      :profiles {:uberjar {:aot :all}})
+    """
+    And a file named "src/foo/core.clj" with:
+    """
+    (ns foo.core
+      (:gen-class))
+
+    (defn get-greeting []
+        "Hello, World!")
+
+    (defn -main
+      "I don't do a whole lot ... yet."
+      [& args]
+      (println (get-greeting)))
+    """
+    And a file named "test/foo/core_test.clj" with:
+    """
+    (ns foo.core-test
+      (:require [clojure.test :refer :all]
+                [foo.core :refer :all]))
+
+    (deftest a-test
+      (testing "say hello"
+        (is (= "Hello, World!" (get-greeting)))))
+    """
+    And a file named "lc.yml" with:
+    """
+    template: lein
+    """
+    And a file named "docker-compose.yml" with:
+    """
+    version: '2'
+    services:
+      noop:
+        image: busybox
+    """
+    When I run `lc bootstrap`
+    Then it should succeed
+    When I run `lc test`
+    Then it should succeed with "0 failures, 0 errors."
+    When I run `lc package`
+    Then it should succeed
+    And the output should contain all of these:
+      | Created /opt/project/target/foo-0.1.0-SNAPSHOT.jar |
+      | 0 failures, 0 errors.                              |
+    And the following folders should not be empty:
+    | target/classes           |

--- a/blackbox-test/features/make.feature
+++ b/blackbox-test/features/make.feature
@@ -29,6 +29,37 @@ Feature: make command
         Then it should succeed
         And the file "foo" should be executable
 
+  Scenario: compile a valid C program using a Makefile and a compose v2 file
+      Given a file named "docker-compose.yml" with:
+      """yaml
+      version: '2'
+      services:  
+        make:
+          image: gcc:6.1
+          volumes:
+            - ./:/project
+          working_dir: /project
+          command: "make"
+      """
+      And a file named "foo.c" with:
+      """
+      #include <stdio.h>
+      int main() {
+          printf("foo\n");
+          return 0;
+      }
+      """
+      And a file named "Makefile" with:
+      """
+      .RECIPEPREFIX = >
+
+      foo: foo.c
+      > gcc -o foo foo.c
+      """
+      When I run `lc make`
+      Then it should succeed
+      And the file "foo" should be executable
+
     Scenario: compile an invalid C program using a Makefile
         Given a file named "docker-compose.yml" with:
         """yaml

--- a/blackbox-test/features/mvn.feature
+++ b/blackbox-test/features/mvn.feature
@@ -93,6 +93,90 @@ Feature: maven template
     | target/classes           |
     | target/test-classes      |
 
+    Scenario: standard maven project with compose v2 file
+      Given a file named "pom.xml" with:
+      """
+      <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+        <modelVersion>4.0.0</modelVersion>
+        <groupId>com.mycompany.app</groupId>
+        <artifactId>my-app</artifactId>
+        <packaging>jar</packaging>
+        <version>1.0-SNAPSHOT</version>
+        <name>my-app</name>
+        <url>http://maven.apache.org</url>
+        <dependencies>
+          <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>3.8.1</version>
+            <scope>test</scope>
+          </dependency>
+        </dependencies>
+      </project>
+      """
+      And a file named "src/main/java/com/mycompany/app/App.java" with:
+      """
+      package com.mycompany.app;
+      public class App
+      {
+          public static void main( String[] args )
+          {
+              System.out.println( "Hello World!" );
+          }
+      }
+      """
+      And a file named "src/test/java/com/mycompany/app/AppTest.java" with:
+      """
+      package com.mycompany.app;
+
+      import junit.framework.Test;
+      import junit.framework.TestCase;
+      import junit.framework.TestSuite;
+
+      public class AppTest
+          extends TestCase
+      {
+          public AppTest( String testName )
+          {
+              super( testName );
+          }
+
+          public static Test suite()
+          {
+              return new TestSuite( AppTest.class );
+          }
+
+          public void testApp()
+          {
+              assertTrue( true );
+          }
+      }
+      """
+      And a file named "lc.yml" with:
+      """
+      template: mvn
+      """
+      And a file named "docker-compose.yml" with:
+      """
+      version: '2'
+      services:
+        noop:
+          image: busybox
+      """
+      When I run `lc bootstrap`
+      Then it should succeed
+      When I run `lc test`
+      Then it should succeed with "BUILD SUCCESS"
+      When I run `lc package`
+      Then it should succeed
+      And the output should contain all of these:
+        | Building jar: /opt/project/target/my-app-1.0-SNAPSHOT.jar |
+        | BUILD SUCCESS                                             |
+      And the following folders should not be empty:
+      | target/classes           |
+      | target/test-classes      |
+
   Scenario: with enable-scratch-volumes
     Given a file named "pom.xml" with:
     """
@@ -171,3 +255,89 @@ Feature: maven template
     | target/test-classes      |
     When I run `lc --enable-scratch-volumes clean`
     Then it should succeed
+
+    Scenario: with enable-scratch-volumes and compose v2 file
+      Given a file named "pom.xml" with:
+      """
+      <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+        <modelVersion>4.0.0</modelVersion>
+        <groupId>com.mycompany.app</groupId>
+        <artifactId>my-app</artifactId>
+        <packaging>jar</packaging>
+        <version>1.0-SNAPSHOT</version>
+        <name>my-app</name>
+        <url>http://maven.apache.org</url>
+        <dependencies>
+          <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>3.8.1</version>
+            <scope>test</scope>
+          </dependency>
+        </dependencies>
+      </project>
+      """
+      And a file named "src/main/java/com/mycompany/app/App.java" with:
+      """
+      package com.mycompany.app;
+      public class App
+      {
+          public static void main( String[] args )
+          {
+              System.out.println( "Hello World!" );
+          }
+      }
+      """
+      And a file named "src/test/java/com/mycompany/app/AppTest.java" with:
+      """
+      package com.mycompany.app;
+
+      import junit.framework.Test;
+      import junit.framework.TestCase;
+      import junit.framework.TestSuite;
+
+      public class AppTest
+          extends TestCase
+      {
+          public AppTest( String testName )
+          {
+              super( testName );
+          }
+
+          public static Test suite()
+          {
+              return new TestSuite( AppTest.class );
+          }
+
+          public void testApp()
+          {
+              assertTrue( true );
+          }
+      }
+      """
+      And a file named "lc.yml" with:
+      """
+      template: mvn
+      """
+      And a file named "docker-compose.yml" with:
+      """
+      version: '2'
+      services:
+        noop:
+          image: busybox
+      """
+      When I run `lc --enable-scratch-volumes bootstrap`
+      Then it should succeed
+      When I run `lc --enable-scratch-volumes test`
+      Then it should succeed with "BUILD SUCCESS"
+      When I run `lc --enable-scratch-volumes package`
+      Then it should succeed
+      And the output should contain all of these:
+        | Building jar: /opt/project/target/my-app-1.0-SNAPSHOT.jar |
+        | BUILD SUCCESS                                             |
+      And the following folders should be empty:
+      | target/classes           |
+      | target/test-classes      |
+      When I run `lc --enable-scratch-volumes clean`
+      Then it should succeed

--- a/blackbox-test/features/sbt.feature
+++ b/blackbox-test/features/sbt.feature
@@ -62,6 +62,53 @@ Feature: sbt template
     | project/project                   |
     | project/target                    |
 
+    Scenario: standard sbt project with compose v2 file
+      Given a file named "hello.scala" with:
+      """scala
+      object Hello {
+        def main(args: Array[String]) = println("Hello World")
+      }
+      """
+      And a file named "project/assembly.sbt" with:
+      """
+      addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.0")
+      """
+      And a file named "build.sbt" with:
+      """
+      scalaVersion := "2.11.0"
+      """
+      And a file named "lc.yml" with:
+      """yaml
+      template: sbt
+      """
+      And a file named "docker-compose.yml" with:
+      """yaml
+      version: '2'
+      services:
+        sbt:
+          image: 1science/sbt
+        test:
+          image: 1science/sbt
+        package:
+          image: 1science/sbt
+        publish:
+          image: 1science/sbt
+        clean:
+          image: 1science/sbt
+      """
+      When I run `lc bootstrap`
+      Then it should succeed
+      When I run `lc test`
+      Then it should succeed with "Compiling 1 Scala source"
+      When I run `lc package`
+      Then it should succeed
+      And it should succeed with "Packaging /opt/project/target/scala-2.11/project-assembly-0.1-SNAPSHOT.jar"
+      And the following folders should not be empty:
+      | target/resolution-cache           |
+      | target/scala-2.11/classes         |
+      | project/project                   |
+      | project/target                    |
+
   Scenario: with enable-scratch-volumes
     Given a file named "hello.scala" with:
     """scala
@@ -106,3 +153,50 @@ Feature: sbt template
     | target/scala-2.11/classes         |
     | project/project                   |
     | project/target                    |
+
+    Scenario: with enable-scratch-volumes and a compopse v2 file
+      Given a file named "hello.scala" with:
+      """scala
+      object Hello {
+        def main(args: Array[String]) = println("Hello World")
+      }
+      """
+      And a file named "project/assembly.sbt" with:
+      """
+      addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.0")
+      """
+      And a file named "build.sbt" with:
+      """
+      scalaVersion := "2.11.0"
+      """
+      And a file named "lc.yml" with:
+      """yaml
+      template: sbt
+      """
+      And a file named "docker-compose.yml" with:
+      """yaml
+      version: '2'
+      services:
+        sbt:
+          image: 1science/sbt
+        test:
+          image: 1science/sbt
+        package:
+          image: 1science/sbt
+        publish:
+          image: 1science/sbt
+        clean:
+          image: 1science/sbt
+      """
+      When I run `lc --enable-scratch-volumes bootstrap`
+      Then it should succeed
+      When I run `lc --enable-scratch-volumes test`
+      Then it should succeed with "Compiling 1 Scala source"
+      When I run `lc --enable-scratch-volumes package`
+      Then it should succeed
+      And it should succeed with "Packaging /opt/project/target/scala-2.11/project-assembly-0.1-SNAPSHOT.jar"
+      And the following folders should be empty:
+      | target/resolution-cache           |
+      | target/scala-2.11/classes         |
+      | project/project                   |
+      | project/target                    |

--- a/blackbox-test/features/system/list-templates.feature
+++ b/blackbox-test/features/system/list-templates.feature
@@ -5,5 +5,7 @@ Feature: system list-templates task
     Then it should succeed
     And the output should contain all of these:
       | Run `lc system view-template <template-name>` to see the template contents. |
+      | Compose v1 Templates: |
       | mvn |
       | sbt |
+      | Compose v2 Templates: |

--- a/blackbox-test/features/system/view-template.feature
+++ b/blackbox-test/features/system/view-template.feature
@@ -6,7 +6,7 @@ Feature: system view-template task
 
   Scenario: calling with an invalid template
     When I run `lc system view-template foo`
-    Then it should fail with 'template \"foo\" is not registered'
+    Then it should fail with 'template \"foo\" is not a registered'
 
   Scenario: calling with a valid template
     When I run `lc system view-template mvn`

--- a/blackbox-test/features/system/view-template.feature
+++ b/blackbox-test/features/system/view-template.feature
@@ -12,6 +12,8 @@ Feature: system view-template task
     When I run `lc system view-template mvn`
     Then it should succeed
     And the output should contain all of these:
-      | mvn:     |
-      | test:    |
-      | package: |
+      | Compose V1 Version: |
+      | mvn:                |
+      | test:               |
+      | package:            |
+      | Compose V2 Version: |

--- a/blackbox-test/features/template.feature
+++ b/blackbox-test/features/template.feature
@@ -7,4 +7,4 @@ Feature: templates
     """
     When I run `lc --template foo bootstrap`
     Then it should fail
-    And the output should contain 'template \"foo\" does not exist'
+    And the output should contain 'template \\\"foo\\\" is not a registered v1 template'

--- a/command/system/list-templates.go
+++ b/command/system/list-templates.go
@@ -2,6 +2,7 @@ package system
 
 import (
 	"fmt"
+
 	"github.com/codegangsta/cli"
 	"github.com/elsy/template"
 )
@@ -9,9 +10,17 @@ import (
 // CmdListTemplates displays an alphabetical list of all available templates
 func CmdListTemplates(c *cli.Context) error {
 	fmt.Println("Run `lc system view-template <template-name>` to see the template contents.")
-	for _, name := range template.List() {
+
+	fmt.Println()
+	fmt.Println("Compose v1 Templates:")
+	for _, name := range template.ListV1() {
 		fmt.Println(name)
 	}
 
+	fmt.Println()
+	fmt.Println("Compose v2 Templates:")
+	for _, name := range template.ListV2() {
+		fmt.Println(name)
+	}
 	return nil
 }

--- a/command/system/view-template.go
+++ b/command/system/view-template.go
@@ -10,7 +10,7 @@ import (
 func CmdViewTemplate(c *cli.Context) error {
 	if templateName := c.Args().First(); len(templateName) == 0 {
 		return fmt.Errorf("view-template requires an argument of the template to view")
-	} else if yaml, err := template.Get(templateName, c.GlobalBool("enable-scratch-volumes")); err != nil {
+	} else if yaml, err := template.GetV1(templateName, c.GlobalBool("enable-scratch-volumes")); err != nil {
 		return err
 	} else {
 		fmt.Println(yaml)

--- a/command/system/view-template.go
+++ b/command/system/view-template.go
@@ -7,13 +7,26 @@ import (
 	"github.com/elsy/template"
 )
 
+// CmdViewTemplate prints out a given template (all versions)
 func CmdViewTemplate(c *cli.Context) error {
-	if templateName := c.Args().First(); len(templateName) == 0 {
+	templateName := c.Args().First()
+	if len(templateName) == 0 {
 		return fmt.Errorf("view-template requires an argument of the template to view")
-	} else if yaml, err := template.GetV1(templateName, c.GlobalBool("enable-scratch-volumes")); err != nil {
-		return err
-	} else {
-		fmt.Println(yaml)
 	}
+
+	yamlV1, err := template.GetV1(templateName, c.GlobalBool("enable-scratch-volumes"))
+	if err != nil {
+		return err
+	}
+	fmt.Println("Compose V1 Version:")
+	fmt.Println(yamlV1)
+
+	yamlV2, err := template.GetV2(templateName, c.GlobalBool("enable-scratch-volumes"))
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("Compose V2 Version:")
+	fmt.Println(yamlV2)
 	return nil
 }

--- a/main/main.go
+++ b/main/main.go
@@ -136,7 +136,7 @@ func setComposeTemplate(c *cli.Context) {
 	templateName := c.GlobalString("template")
 	enableScratchVolume := c.GlobalBool("enable-scratch-volumes")
 	if len(templateName) > 0 {
-		if yaml, err := template.Get(templateName, enableScratchVolume); err == nil {
+		if yaml, err := template.GetV1(templateName, enableScratchVolume); err == nil {
 			file := createTempComposeFile(yaml)
 			logrus.Debugf("setting LC_BASE_COMPOSE_FILE to %v", file)
 			os.Setenv("LC_BASE_COMPOSE_FILE", file)

--- a/main/main.go
+++ b/main/main.go
@@ -136,19 +136,19 @@ func setComposeTemplate(c *cli.Context) {
 	templateName := c.GlobalString("template")
 	enableScratchVolume := c.GlobalBool("enable-scratch-volumes")
 	if len(templateName) > 0 {
-		if yaml, err := template.GetV1(templateName, enableScratchVolume); err == nil {
+		if yaml, err := template.GetTemplate(templateName, enableScratchVolume); err == nil {
 			file := createTempComposeFile(yaml)
 			logrus.Debugf("setting LC_BASE_COMPOSE_FILE to %v", file)
 			os.Setenv("LC_BASE_COMPOSE_FILE", file)
 		} else {
-			logrus.Panicf("template %q does not exist", templateName)
+			logrus.Panicf("error finding template %q, err: %q", templateName, err)
 		}
-	}
 
-	dataContainers := template.GetSharedExternalDataContainers(templateName)
-	for _, dataContainer := range dataContainers {
-		if err := dataContainer.Ensure(c.GlobalBool("offline")); err != nil {
-			logrus.Panic("unable to create data container")
+		dataContainers := template.GetSharedExternalDataContainers(templateName)
+		for _, dataContainer := range dataContainers {
+			if err := dataContainer.Ensure(c.GlobalBool("offline")); err != nil {
+				logrus.Panic("unable to create data container")
+			}
 		}
 	}
 }

--- a/template/lein.go
+++ b/template/lein.go
@@ -47,6 +47,53 @@ clean:
   - /opt/project/target/webappDirectory
 `}
 
+var leinTemplateV2 = template{
+	name: "lein",
+	composeYmlTmpl: `
+version: '2'
+services:
+  {{if .ScratchVolumes}}
+  mvnscratch:
+    image: busybox
+    volumes:
+      {{.ScratchVolumes}}
+    entrypoint: /bin/true
+  {{end}}
+  lein: &lein
+    image: clojure:lein-2.6.1
+    volumes:
+      - ./:/opt/project
+    working_dir: /opt/project
+    entrypoint: lein
+    volumes_from:
+      - container:lc_shared_mvndata
+  {{if .ScratchVolumes}}
+      - mvnscratch
+  {{end}}
+  test:
+    <<: *lein
+    entrypoint: [lein, test]
+  package:
+    <<: *lein
+    command: [jar, "-DskipTests=true"]
+  publish:
+    <<: *lein
+    entrypoint: /bin/true
+  clean:
+    <<: *lein
+    entrypoint: [lein, clean]
+`,
+	scratchVolumes: `
+    - /opt/project/target/classes
+    - /opt/project/target/journal
+    - /opt/project/target/maven-archiver
+    - /opt/project/target/maven-status
+    - /opt/project/target/snapshots
+    - /opt/project/target/test-classes
+    - /opt/project/target/war/work
+    - /opt/project/target/webappDirectory
+`}
+
 func init() {
 	addSharedExternalDataContainer("lein", helpers.DockerDataContainer{
 		Image:     "busybox:latest",
@@ -56,4 +103,5 @@ func init() {
 	})
 
 	addV1(leinTemplateV1)
+	addV2(leinTemplateV2)
 }

--- a/template/lein.go
+++ b/template/lein.go
@@ -2,7 +2,7 @@ package template
 
 import "github.com/elsy/helpers"
 
-var leinTemplate = template{
+var leinTemplateV1 = template{
 	name: "lein",
 	composeYmlTmpl: `
 {{if .ScratchVolumes}}
@@ -48,12 +48,12 @@ clean:
 `}
 
 func init() {
-	AddSharedExternalDataContainer("lein", helpers.DockerDataContainer{
+	addSharedExternalDataContainer("lein", helpers.DockerDataContainer{
 		Image:     "busybox:latest",
 		Name:      "lc_shared_mvndata",
 		Volumes:   []string{"/root/.m2/repository"},
 		Resilient: true,
 	})
 
-	Add(leinTemplate)
+	addV1(leinTemplateV1)
 }

--- a/template/library.go
+++ b/template/library.go
@@ -121,9 +121,22 @@ func GetV2(name string, enableScratchVolume bool) (string, error) {
 	return yml, nil
 }
 
-// List will return a slice of all known templates
-func List() []string {
+// ListV1 will return a slice of all known v1 templates
+func ListV1() []string {
 	keys := make([]string, 0, len(templatesV1))
+
+	for k := range templatesV1 {
+		keys = append(keys, k)
+	}
+
+	sort.Strings(keys)
+
+	return keys
+}
+
+// ListV2 will return a slice of all known v2 templates
+func ListV2() []string {
+	keys := make([]string, 0, len(templatesV2))
 
 	for k := range templatesV1 {
 		keys = append(keys, k)

--- a/template/library.go
+++ b/template/library.go
@@ -4,17 +4,19 @@ import (
 	"bytes"
 	"fmt"
 	"sort"
-	"github.com/elsy/helpers"
 	tmpl "text/template"
+
+	"github.com/elsy/helpers"
 )
 
 var sharedExternalDataContainers = make(map[string][]helpers.DockerDataContainer)
 
-func AddSharedExternalDataContainer(templateName string, ddc helpers.DockerDataContainer) {
+func addSharedExternalDataContainer(templateName string, ddc helpers.DockerDataContainer) {
 	dataContainers := GetSharedExternalDataContainers(templateName)
 	sharedExternalDataContainers[templateName] = append(dataContainers, ddc)
 }
 
+// GetSharedExternalDataContainers will return a slice of data containers used by the given template
 func GetSharedExternalDataContainers(templateName string) []helpers.DockerDataContainer {
 	return sharedExternalDataContainers[templateName]
 }
@@ -51,36 +53,37 @@ func (t *template) toYml(enableScratchVolume bool) (string, error) {
 	return finalYml.String(), nil
 }
 
-var templates = make(map[string]template)
+var templatesV1 = make(map[string]template)
 
-// Add will add the given template to a registry for use by external packages
-func Add(template template) error {
-	if _, ok := templates[template.name]; ok {
+// addV1 will add the given compose v1 template to a registry for use by external packages
+func addV1(template template) error {
+	if _, ok := templatesV1[template.name]; ok {
 		return fmt.Errorf("template %q already exists", template.name)
 	}
-	templates[template.name] = template
+	templatesV1[template.name] = template
 	return nil
 }
 
-// Get will return the template if it exists
+// GetV1 will return the compose V1 template if it exists
 // If 'enableScratchVolume' is true and the target template supports
 // scratch-space optimization then Get will enable it.
-func Get(name string, enableScratchVolume bool) (string, error) {
-	template, present := templates[name]
+func GetV1(name string, enableScratchVolume bool) (string, error) {
+	tmpl, present := templatesV1[name]
 	if !present {
 		return "", fmt.Errorf("template %q is not registered", name)
 	}
-	yml, err := template.toYml(enableScratchVolume)
+	yml, err := tmpl.toYml(enableScratchVolume)
 	if err != nil {
 		return "", err
 	}
 	return yml, nil
 }
 
+// List will return a slice of all known templates
 func List() []string {
-	keys := make([]string, 0, len(templates))
+	keys := make([]string, 0, len(templatesV1))
 
-	for k := range templates {
+	for k := range templatesV1 {
 		keys = append(keys, k)
 	}
 

--- a/template/library_test.go
+++ b/template/library_test.go
@@ -24,29 +24,29 @@ func TestSharedExternalDataContainer(t *testing.T) {
 		t.Error("expected shared external data containers to start empty")
 	}
 
-	AddSharedExternalDataContainer("foo", ddcTmp)
-	AddSharedExternalDataContainer("foo", ddcVar)
+	addSharedExternalDataContainer("foo", ddcTmp)
+	addSharedExternalDataContainer("foo", ddcVar)
 	if dataContainers := GetSharedExternalDataContainers("foo"); len(dataContainers) != 2 {
 		t.Error("expected shared external data containers to contain added containers")
 	}
 
-	AddSharedExternalDataContainer("bar", ddcVar)
+	addSharedExternalDataContainer("bar", ddcVar)
 	if dataContainers := GetSharedExternalDataContainers("bar"); len(dataContainers) != 1 {
 		t.Error("expected shared external data containers to contain added containers")
 	}
 }
 
-func TestTemplateRegistration(t *testing.T) {
-	if _, err := Get("foo", false); err == nil {
+func TestTemplateV1Registration(t *testing.T) {
+	if _, err := GetV1("foo", false); err == nil {
 		t.Error("expected Get to return an error for a non-existant template")
 	}
-	if err := Add(template{name: "foo", composeYmlTmpl: "someyaml"}); err != nil {
+	if err := addV1(template{name: "foo", composeYmlTmpl: "someyaml"}); err != nil {
 		t.Error("expected Add to register a template")
 	}
-	if _, err := Get("foo", false); err != nil {
+	if _, err := GetV1("foo", false); err != nil {
 		t.Error("expected Get to return yaml after registering a template")
 	}
-	if err := Add(template{name: "foo", composeYmlTmpl: "someyaml"}); err == nil {
+	if err := addV1(template{name: "foo", composeYmlTmpl: "someyaml"}); err == nil {
 		t.Error("expected Add to return an error when registering an existing template")
 	}
 }

--- a/template/library_test.go
+++ b/template/library_test.go
@@ -50,3 +50,18 @@ func TestTemplateV1Registration(t *testing.T) {
 		t.Error("expected Add to return an error when registering an existing template")
 	}
 }
+
+func TestTemplateV2Registration(t *testing.T) {
+	if _, err := GetV2("foo", false); err == nil {
+		t.Error("expected Get to return an error for a non-existant template")
+	}
+	if err := addV2(template{name: "foo", composeYmlTmpl: "someyaml"}); err != nil {
+		t.Error("expected Add to register a template")
+	}
+	if _, err := GetV2("foo", false); err != nil {
+		t.Error("expected Get to return yaml after registering a template")
+	}
+	if err := addV2(template{name: "foo", composeYmlTmpl: "someyaml"}); err == nil {
+		t.Error("expected Add to return an error when registering an existing template")
+	}
+}

--- a/template/make.go
+++ b/template/make.go
@@ -17,6 +17,26 @@ clean:
   entrypoint: [make, clean]
 `}
 
+var makeTemplateV2 = template{
+	name: "make",
+	composeYmlTmpl: `
+version: '2'
+services:
+  make: &make
+    image: gcc:6.1
+    volumes:
+      - ./:/opt/project
+    working_dir: /opt/project
+    entrypoint: make
+  test:
+    <<: *make
+    entrypoint: [make, test]
+  clean:
+    <<: *make
+    entrypoint: [make, clean]
+`}
+
 func init() {
 	addV1(makeTemplateV1)
+	addV2(makeTemplateV2)
 }

--- a/template/make.go
+++ b/template/make.go
@@ -1,6 +1,6 @@
 package template
 
-var makeTemplate = template{
+var makeTemplateV1 = template{
 	name: "make",
 	composeYmlTmpl: `
 make: &make
@@ -18,5 +18,5 @@ clean:
 `}
 
 func init() {
-	Add(makeTemplate)
+	addV1(makeTemplateV1)
 }

--- a/template/mvn.go
+++ b/template/mvn.go
@@ -53,6 +53,59 @@ clean:
   - /opt/project/target/webappDirectory
 `}
 
+var mvnTemplateV2 = template{
+	name: "mvn",
+	composeYmlTmpl: `
+version: '2'
+services:
+  {{if .ScratchVolumes}}
+  mvnscratch:
+    image: busybox
+    volumes:
+      {{.ScratchVolumes}}
+    entrypoint: /bin/true
+  {{end}}
+  mvn: &mvn
+    image: maven:3.2-jdk-8
+    volumes:
+      - ./:/opt/project
+    working_dir: /opt/project
+    entrypoint: mvn
+    volumes_from:
+      - container:lc_shared_mvndata
+  {{if .ScratchVolumes}}
+      - mvnscratch
+  {{end}}
+  test:
+    <<: *mvn
+    entrypoint: [mvn, test]
+  package:
+    <<: *mvn
+    command: [package, "-DskipTests=true"]
+  publish:
+    <<: *mvn
+    entrypoint: /bin/true
+  {{if .ScratchVolumes}}
+  clean:
+    <<: *mvn
+    entrypoint: [mvn, clean, "-Dmaven.clean.failOnError=false"]
+  {{else}}
+  clean:
+    <<: *mvn
+    entrypoint: [mvn, clean]
+  {{end}}
+`,
+	scratchVolumes: `
+    - /opt/project/target/classes
+    - /opt/project/target/journal
+    - /opt/project/target/maven-archiver
+    - /opt/project/target/maven-status
+    - /opt/project/target/snapshots
+    - /opt/project/target/test-classes
+    - /opt/project/target/war/work
+    - /opt/project/target/webappDirectory
+`}
+
 func init() {
 	addSharedExternalDataContainer("mvn", helpers.DockerDataContainer{
 		Image:     "busybox:latest",
@@ -62,4 +115,5 @@ func init() {
 	})
 
 	addV1(mvnTemplateV1)
+	addV2(mvnTemplateV2)
 }

--- a/template/mvn.go
+++ b/template/mvn.go
@@ -2,7 +2,7 @@ package template
 
 import "github.com/elsy/helpers"
 
-var mvnTemplate = template{
+var mvnTemplateV1 = template{
 	name: "mvn",
 	composeYmlTmpl: `
 {{if .ScratchVolumes}}
@@ -54,12 +54,12 @@ clean:
 `}
 
 func init() {
-	AddSharedExternalDataContainer("mvn", helpers.DockerDataContainer{
+	addSharedExternalDataContainer("mvn", helpers.DockerDataContainer{
 		Image:     "busybox:latest",
 		Name:      "lc_shared_mvndata",
 		Volumes:   []string{"/root/.m2/repository"},
 		Resilient: true,
 	})
 
-	Add(mvnTemplate)
+	addV1(mvnTemplateV1)
 }

--- a/template/mvn_test.go
+++ b/template/mvn_test.go
@@ -10,4 +10,8 @@ func TestMvnTemplate(t *testing.T) {
 	if _, err := GetV1("mvn", false); err != nil {
 		t.Error("expected mvn template to be registered")
 	}
+
+	if _, err := GetV2("mvn", false); err != nil {
+		t.Error("expected mvn template to be registered")
+	}
 }

--- a/template/mvn_test.go
+++ b/template/mvn_test.go
@@ -7,7 +7,7 @@ func TestMvnTemplate(t *testing.T) {
 		t.Error("expected mvn template to register one shared external data container")
 	}
 
-	if _, err := Get("mvn", false); err != nil {
+	if _, err := GetV1("mvn", false); err != nil {
 		t.Error("expected mvn template to be registered")
 	}
 }

--- a/template/sbt.go
+++ b/template/sbt.go
@@ -2,7 +2,7 @@ package template
 
 import "github.com/elsy/helpers"
 
-var sbtTemplate = template{
+var sbtTemplateV1 = template{
 	name: "sbt",
 	composeYmlTmpl: `
 {{if .ScratchVolumes}}
@@ -46,12 +46,12 @@ clean:
 `}
 
 func init() {
-	AddSharedExternalDataContainer("sbt", helpers.DockerDataContainer{
+	addSharedExternalDataContainer("sbt", helpers.DockerDataContainer{
 		Image:     "busybox:latest",
 		Name:      "lc_shared_sbtdata",
 		Volumes:   []string{"/root/.ivy2"},
 		Resilient: true,
 	})
 
-	Add(sbtTemplate)
+	addV1(sbtTemplateV1)
 }

--- a/template/sbt.go
+++ b/template/sbt.go
@@ -45,6 +45,51 @@ clean:
     - /opt/project/project/target
 `}
 
+var sbtTemplateV2 = template{
+	name: "sbt",
+	composeYmlTmpl: `
+version: '2'
+services:
+  {{if .ScratchVolumes}}
+  sbtscratch:
+    image: busybox
+    command: /bin/true
+    volumes:
+      {{.ScratchVolumes}}
+  {{end}}
+  sbt: &sbt
+    image: arch-docker.eng.lancope.local:5000/sbt
+    volumes:
+      - ./:/opt/project
+    working_dir: /opt/project
+    entrypoint: sbt
+    volumes_from:
+      - container:lc_shared_sbtdata
+  {{if .ScratchVolumes}}
+      - sbtscratch
+  {{end}}
+  test:
+    <<: *sbt
+    entrypoint: [sbt, test]
+  package:
+    <<: *sbt
+    command: [assembly]
+  publish:
+    <<: *sbt
+    entrypoint: /bin/true
+  clean:
+    <<: *sbt
+    entrypoint: [sbt, clean]
+`,
+	scratchVolumes: `
+      - /opt/project/target/resolution-cache
+      - /opt/project/target/scala-2.11/classes
+      - /opt/project/target/scala-2.11/test-classes
+      - /opt/project/target/streams
+      - /opt/project/project/project
+      - /opt/project/project/target
+`}
+
 func init() {
 	addSharedExternalDataContainer("sbt", helpers.DockerDataContainer{
 		Image:     "busybox:latest",
@@ -54,4 +99,5 @@ func init() {
 	})
 
 	addV1(sbtTemplateV1)
+	addV2(sbtTemplateV2)
 }

--- a/template/sbt_test.go
+++ b/template/sbt_test.go
@@ -7,7 +7,7 @@ func TestSbtTemplate(t *testing.T) {
 		t.Error("expected sbt template to register one shared external data container")
 	}
 
-	if _, err := Get("sbt", false); err != nil {
+	if _, err := GetV1("sbt", false); err != nil {
 		t.Error("expected sbt template to be registered")
 	}
 }

--- a/template/sbt_test.go
+++ b/template/sbt_test.go
@@ -10,4 +10,8 @@ func TestSbtTemplate(t *testing.T) {
 	if _, err := GetV1("sbt", false); err != nil {
 		t.Error("expected sbt template to be registered")
 	}
+
+	if _, err := GetV2("sbt", false); err != nil {
+		t.Error("expected sbt template to be registered")
+	}
 }


### PR DESCRIPTION
This implements #7 . We can now use `docker-compose.yml` files with the v2 syntax when using [elsy templates](https://github.com/cisco/elsy/blob/master/docs/templates.md).

However it still keeps v1 templates as the default if a compose file is not found for the repo. I think its better to start testing out the v2 templates in beta mode for a bit before we make them the default.

Notes for the future: When we do switch to v2 file format as the default we need to:

- add deprecation warning for v1 compose files if found in a repo
- update all blackbox-tests to use the v2 format
- update the template docs to use v2 
- update the way we create the shared data containers (e.g., `lc_shared_mvndata`) to use `docker volume create`.

cc @joeygibson @munkyboy 