### PR TITLE
Public sbt Image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+- sbt template now uses the `paulcichonski/sbt` Docker image. This is not an
+official Docker image (no official sbt image exists) so users should still
+override this image with an image they have vetted.
+
 ## v1.4.0
 
 - Added `lc run` to keep from having to type `lc dc run`. Any aguments that `lc dc run` takes,

--- a/blackbox-test/features/clean.feature
+++ b/blackbox-test/features/clean.feature
@@ -185,19 +185,6 @@ Feature: cleaning house
     """yaml
     template: sbt
     """
-    And a file named "docker-compose.yml" with:
-    """yaml
-    sbt:
-      image: 1science/sbt
-    test:
-      image: 1science/sbt
-    package:
-      image: 1science/sbt
-    publish:
-      image: 1science/sbt
-    clean:
-      image: 1science/sbt
-    """
     When I run `lc bootstrap`
     Then it should succeed
     When I run `lc test`

--- a/blackbox-test/features/sbt.feature
+++ b/blackbox-test/features/sbt.feature
@@ -36,19 +36,6 @@ Feature: sbt template
     """yaml
     template: sbt
     """
-    And a file named "docker-compose.yml" with:
-    """yaml
-    sbt:
-      image: 1science/sbt
-    test:
-      image: 1science/sbt
-    package:
-      image: 1science/sbt
-    publish:
-      image: 1science/sbt
-    clean:
-      image: 1science/sbt
-    """
     When I run `lc bootstrap`
     Then it should succeed
     When I run `lc test`
@@ -86,15 +73,7 @@ Feature: sbt template
       version: '2'
       services:
         sbt:
-          image: 1science/sbt
-        test:
-          image: 1science/sbt
-        package:
-          image: 1science/sbt
-        publish:
-          image: 1science/sbt
-        clean:
-          image: 1science/sbt
+          image: paulcichonski/sbt
       """
       When I run `lc bootstrap`
       Then it should succeed
@@ -127,19 +106,6 @@ Feature: sbt template
     And a file named "lc.yml" with:
     """yaml
     template: sbt
-    """
-    And a file named "docker-compose.yml" with:
-    """yaml
-    sbt:
-      image: 1science/sbt
-    test:
-      image: 1science/sbt
-    package:
-      image: 1science/sbt
-    publish:
-      image: 1science/sbt
-    clean:
-      image: 1science/sbt
     """
     When I run `lc --enable-scratch-volumes bootstrap`
     Then it should succeed
@@ -178,15 +144,7 @@ Feature: sbt template
       version: '2'
       services:
         sbt:
-          image: 1science/sbt
-        test:
-          image: 1science/sbt
-        package:
-          image: 1science/sbt
-        publish:
-          image: 1science/sbt
-        clean:
-          image: 1science/sbt
+          image: paulcichonski/sbt
       """
       When I run `lc --enable-scratch-volumes bootstrap`
       Then it should succeed

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -5,7 +5,8 @@ submit a patch to elsy, please submit a PR to the `master` branch.
 
 ## Local Development
 
-Use elsy to develop elsy!
+Use elsy to develop elsy! Currently docker 1.11 is required to run
+blackbox-tests.
 
 This repo exposes all of the core elsy tasks for ongoing development:
 

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -128,8 +128,8 @@ clean:
 
 ### sbt
 
-**The sbt template currently leverages a private Docker image for its sbt install
-so to use this template you must override this image for now**
+**Currently there is no official sbt Docker image, it is STRONGLY recommended that
+you override the default image baked into the elsy sbt template.**
 
 To use the mvn template, ensure your `lc.yml` has the line:
 

--- a/template/sbt.go
+++ b/template/sbt.go
@@ -13,7 +13,7 @@ sbtscratch:
     {{.ScratchVolumes}}
 {{end}}
 sbt: &sbt
-  image: arch-docker.eng.lancope.local:5000/sbt
+  image: paulcichonski/sbt
   volumes:
     - ./:/opt/project
   working_dir: /opt/project
@@ -58,7 +58,7 @@ services:
       {{.ScratchVolumes}}
   {{end}}
   sbt: &sbt
-    image: arch-docker.eng.lancope.local:5000/sbt
+    image: paulcichonski/sbt
     volumes:
       - ./:/opt/project
     working_dir: /opt/project


### PR DESCRIPTION
Fixes #15

This switches the sbt image to use `paulcichonski/sbt`, which is still not official, but at least it is public and we can control it. Also added a strongly phrased recommendation to the docs saying that users should override this default image. This isn't ideal, but it is better than using an image that does not exist.
