### PR TITLE
Updated package names to match Go standard.

### DIFF
--- a/command/blackboxtest.go
+++ b/command/blackboxtest.go
@@ -19,7 +19,7 @@ package command
 import (
 	"github.com/Sirupsen/logrus"
 	"github.com/codegangsta/cli"
-	"github.com/elsy/helpers"
+	"github.com/cisco/elsy/helpers"
 )
 
 // CmdBlackbox processes cmd args and then runs blackbox tests

--- a/command/bootstrap.go
+++ b/command/bootstrap.go
@@ -21,7 +21,7 @@ import (
 	"regexp"
 
 	"github.com/codegangsta/cli"
-	"github.com/elsy/helpers"
+	"github.com/cisco/elsy/helpers"
 )
 
 // CmdBootstrap pulls and builds the services in the docker-compose file

--- a/command/ci.go
+++ b/command/ci.go
@@ -19,7 +19,7 @@ package command
 import (
 	"github.com/Sirupsen/logrus"
 	"github.com/codegangsta/cli"
-	"github.com/elsy/helpers"
+	"github.com/cisco/elsy/helpers"
 )
 
 // CmdCi runs ci loop

--- a/command/clean.go
+++ b/command/clean.go
@@ -18,7 +18,7 @@ package command
 
 import (
 	"github.com/codegangsta/cli"
-	"github.com/elsy/helpers"
+	"github.com/cisco/elsy/helpers"
 )
 
 // CmdClean will run a "clean" service that will remove old build artifacts.

--- a/command/docker-compose.go
+++ b/command/docker-compose.go
@@ -18,7 +18,7 @@ package command
 
 import (
 	"github.com/codegangsta/cli"
-	"github.com/elsy/helpers"
+	"github.com/cisco/elsy/helpers"
 )
 
 func CmdDockerCompose(c *cli.Context) error {

--- a/command/install-dependencies.go
+++ b/command/install-dependencies.go
@@ -19,7 +19,7 @@ package command
 import (
 	"github.com/Sirupsen/logrus"
 	"github.com/codegangsta/cli"
-	"github.com/elsy/helpers"
+	"github.com/cisco/elsy/helpers"
 )
 
 func CmdInstallDependencies(c *cli.Context) error {

--- a/command/lein.go
+++ b/command/lein.go
@@ -18,7 +18,7 @@ package command
 
 import (
 	"github.com/codegangsta/cli"
-	"github.com/elsy/helpers"
+	"github.com/cisco/elsy/helpers"
 )
 
 func CmdLein(c *cli.Context) error {

--- a/command/make.go
+++ b/command/make.go
@@ -18,7 +18,7 @@ package command
 
 import (
 	"github.com/codegangsta/cli"
-	"github.com/elsy/helpers"
+	"github.com/cisco/elsy/helpers"
 )
 
 func CmdMake(c *cli.Context) error {

--- a/command/mvn.go
+++ b/command/mvn.go
@@ -1,12 +1,12 @@
 /*
  *  Copyright 2016 Cisco Systems, Inc.
- *  
+ *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
- *  
+ *
  *  http://www.apache.org/licenses/LICENSE-2.0
- *  
+ *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -18,7 +18,7 @@ package command
 
 import (
 	"github.com/codegangsta/cli"
-	"github.com/elsy/helpers"
+	"github.com/cisco/elsy/helpers"
 )
 
 func CmdMvn(c *cli.Context) error {

--- a/command/package.go
+++ b/command/package.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/codegangsta/cli"
-	"github.com/elsy/helpers"
+	"github.com/cisco/elsy/helpers"
 )
 
 // commitLabel identifies the git commit the image was built from

--- a/command/publish.go
+++ b/command/publish.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/codegangsta/cli"
-	"github.com/elsy/helpers"
+	"github.com/cisco/elsy/helpers"
 )
 
 // CmdPublish will publish all artifacts associated with the current repo

--- a/command/release.go
+++ b/command/release.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/codegangsta/cli"
-	"github.com/elsy/helpers"
+	"github.com/cisco/elsy/helpers"
 )
 
 // CmdRelease will create, and push a release tag

--- a/command/run.go
+++ b/command/run.go
@@ -18,7 +18,7 @@ package command
 
 import (
 	"github.com/codegangsta/cli"
-	"github.com/elsy/helpers"
+	"github.com/cisco/elsy/helpers"
 )
 
 func CmdRun(c *cli.Context) error {

--- a/command/sbt.go
+++ b/command/sbt.go
@@ -18,7 +18,7 @@ package command
 
 import (
 	"github.com/codegangsta/cli"
-	"github.com/elsy/helpers"
+	"github.com/cisco/elsy/helpers"
 )
 
 func CmdSbt(c *cli.Context) error {

--- a/command/server/log.go
+++ b/command/server/log.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/codegangsta/cli"
-	"github.com/elsy/helpers"
+	"github.com/cisco/elsy/helpers"
 )
 
 func CmdLog(c *cli.Context) error {

--- a/command/server/start.go
+++ b/command/server/start.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/codegangsta/cli"
-	"github.com/elsy/helpers"
+	"github.com/cisco/elsy/helpers"
 )
 
 func CmdStart(c *cli.Context) error {

--- a/command/server/status.go
+++ b/command/server/status.go
@@ -22,7 +22,7 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/codegangsta/cli"
 	"github.com/fatih/color"
-	"github.com/elsy/helpers"
+	"github.com/cisco/elsy/helpers"
 )
 
 func CmdStatus(c *cli.Context) error {

--- a/command/server/stop.go
+++ b/command/server/stop.go
@@ -19,7 +19,7 @@ package server
 import (
 	"github.com/Sirupsen/logrus"
 	"github.com/codegangsta/cli"
-	"github.com/elsy/helpers"
+	"github.com/cisco/elsy/helpers"
 )
 
 func CmdStop(c *cli.Context) error {

--- a/command/system/list-templates.go
+++ b/command/system/list-templates.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 
 	"github.com/codegangsta/cli"
-	"github.com/elsy/template"
+	"github.com/cisco/elsy/template"
 )
 
 // CmdListTemplates displays an alphabetical list of all available templates

--- a/command/system/verify-install.go
+++ b/command/system/verify-install.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/codegangsta/cli"
-	"github.com/elsy/helpers"
+	"github.com/cisco/elsy/helpers"
 )
 
 // file that we will use to verify volume mounts are working, assumption is that every lc repo should include this

--- a/command/system/view-template.go
+++ b/command/system/view-template.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 
 	"github.com/codegangsta/cli"
-	"github.com/elsy/template"
+	"github.com/cisco/elsy/template"
 )
 
 // CmdViewTemplate prints out a given template (all versions)

--- a/command/teardown.go
+++ b/command/teardown.go
@@ -23,7 +23,7 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/codegangsta/cli"
 	"github.com/fsouza/go-dockerclient"
-	"github.com/elsy/helpers"
+	"github.com/cisco/elsy/helpers"
 )
 
 func CmdTeardown(c *cli.Context) error {

--- a/command/test.go
+++ b/command/test.go
@@ -18,7 +18,7 @@ package command
 
 import (
 	"github.com/codegangsta/cli"
-	"github.com/elsy/helpers"
+	"github.com/cisco/elsy/helpers"
 )
 
 func CmdTest(c *cli.Context) error {

--- a/dev-env/package
+++ b/dev-env/package
@@ -34,8 +34,8 @@ fi
 
 for platform in "${platforms[@]}"; do
   GOOS=${platform} GOARCH=${arch} go build -v -o target/lc-${platform}-${arch}-${version} \
-    --ldflags "-X github.com/elsy/helpers.version=$version \
-    -X github.com/elsy/helpers.build=$build" \
+    --ldflags "-X github.com/cisco/elsy/helpers.version=$version \
+    -X github.com/cisco/elsy/helpers.build=$build" \
     ./main
 done
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,8 +15,8 @@
 go: &go
   build: dev-env
   volumes:
-    - .:/go/src/github.com/elsy
-  working_dir: /go/src/github.com/elsy
+    - .:/go/src/github.com/cisco/elsy
+  working_dir: /go/src/github.com/cisco/elsy
   environment:
     - GOOS
     - GOARCH

--- a/main/commands.go
+++ b/main/commands.go
@@ -22,9 +22,9 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/codegangsta/cli"
-	"github.com/elsy/command"
-	"github.com/elsy/command/server"
-	"github.com/elsy/command/system"
+	"github.com/cisco/elsy/command"
+	"github.com/cisco/elsy/command/server"
+	"github.com/cisco/elsy/command/system"
 )
 
 // GlobalFlags sets up flags on the lc command proper

--- a/main/main.go
+++ b/main/main.go
@@ -28,8 +28,8 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/codegangsta/cli"
-	"github.com/elsy/helpers"
-	"github.com/elsy/template"
+	"github.com/cisco/elsy/helpers"
+	"github.com/cisco/elsy/template"
 )
 
 func main() {

--- a/template/lein.go
+++ b/template/lein.go
@@ -16,7 +16,7 @@
 
 package template
 
-import "github.com/elsy/helpers"
+import "github.com/cisco/elsy/helpers"
 
 var leinTemplateV1 = template{
 	name: "lein",

--- a/template/library.go
+++ b/template/library.go
@@ -23,7 +23,7 @@ import (
 	"sort"
 	tmpl "text/template"
 
-	"github.com/elsy/helpers"
+	"github.com/cisco/elsy/helpers"
 )
 
 var sharedExternalDataContainers = make(map[string][]helpers.DockerDataContainer)

--- a/template/library_test.go
+++ b/template/library_test.go
@@ -19,7 +19,7 @@ package template
 import (
 	"testing"
 
-	"github.com/elsy/helpers"
+	"github.com/cisco/elsy/helpers"
 )
 
 func TestSharedExternalDataContainer(t *testing.T) {

--- a/template/mvn.go
+++ b/template/mvn.go
@@ -16,7 +16,7 @@
 
 package template
 
-import "github.com/elsy/helpers"
+import "github.com/cisco/elsy/helpers"
 
 var mvnTemplateV1 = template{
 	name: "mvn",

--- a/template/sbt.go
+++ b/template/sbt.go
@@ -16,7 +16,7 @@
 
 package template
 
-import "github.com/elsy/helpers"
+import "github.com/cisco/elsy/helpers"
 
 var sbtTemplateV1 = template{
 	name: "sbt",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -149,5 +149,5 @@
 			"revisionTime": "2016-03-01T20:40:22Z"
 		}
 	],
-	"rootPath": "github.com/elsy"
+	"rootPath": "github.com/cisco/elsy"
 }


### PR DESCRIPTION
We were using `github.com/elsy` as our base package name, but it the Go standards say it should be `github.com/cisco/elsy`, to reflect its actual location on the Internet. (It's a dumb standard, but it's still their standard.)