### PR TITLE
Fixed to work with versions like 1.13.0-rc2

### DIFF
--- a/helpers/docker.go
+++ b/helpers/docker.go
@@ -1,12 +1,12 @@
 /*
  *  Copyright 2016 Cisco Systems, Inc.
- *  
+ *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
- *  
+ *
  *  http://www.apache.org/licenses/LICENSE-2.0
- *  
+ *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -250,6 +250,13 @@ func GetDockerVersion() (string, []int, error) {
 
 // parseVersionString assumes version string of format <major>.<minor>.<patch>
 func parseVersionString(versionString string) ([]int, error) {
+
+	// This is to guard against beta or RC versions of Docker, which
+	// lookg like `1.13.0-rc2` breaking the parsing logic
+	if strings.Contains(versionString, "-") {
+		versionString = strings.Split(versionString, "-")[0]
+	}
+
 	versionArray := strings.Split(versionString, ".")
 
 	if len(versionArray) != 3 {

--- a/helpers/docker_test.go
+++ b/helpers/docker_test.go
@@ -1,12 +1,12 @@
 /*
  *  Copyright 2016 Cisco Systems, Inc.
- *  
+ *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
- *  
+ *
  *  http://www.apache.org/licenses/LICENSE-2.0
- *  
+ *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -28,6 +28,7 @@ var testVersionStringData = []struct {
 	{"1.9.1", []int{1, 9, 1}},
 	{"1.10.3", []int{1, 10, 3}},
 	{"1.11.2", []int{1, 11, 2}},
+	{"1.13.0-rc2", []int{1, 13, 0}},
 	{"", nil},
 }
 


### PR DESCRIPTION
I discovered that the `package` bbtest was failing, and I tracked it down to the fact that my version of Docker is 1.13.0-rc2, which was causing the version parsing logic to break. This fixes that.