### PR TITLE
Fixes #4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Unreleased
 
+- When releasing, it now checks for an existing tag or branch that is the same as the `--version` argument
+and gives a better explanation of what happened.
+- Fixed a bug that happened in packaging if the verison of Docker had something like `-rc2` at the end.
+- Fixed issue #4, which would cause a panic in rare cases during packaging.
+
 ## v1.6.0
 
 - Added the ability to override the image that a template uses by setting 

--- a/blackbox-test/features/package.feature
+++ b/blackbox-test/features/package.feature
@@ -1,11 +1,11 @@
 # Copyright 2016 Cisco Systems, Inc.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 # http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/command/package.go
+++ b/command/package.go
@@ -1,12 +1,12 @@
 /*
  *  Copyright 2016 Cisco Systems, Inc.
- *  
+ *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
- *  
+ *
  *  http://www.apache.org/licenses/LICENSE-2.0
- *  
+ *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/helpers/docker.go
+++ b/helpers/docker.go
@@ -85,18 +85,22 @@ func RemoveContainersOfImage(image string) error {
 			// in the api responses, so for now just check all locations where docker
 			// lists the image value.
 			// It seems that client.InspectContainer.Config.Image is the most trustworthy though
+
 			inspection, err := client.InspectContainer(container.ID)
+
 			if err != nil {
 				logrus.Debugf("could not inspect container %q", container.ID)
-			}
-			if container.Image == image || inspection.Image == image || inspection.Config.Image == image {
-				logrus.Debugf("removing container: %s", container.ID)
-				options := docker.RemoveContainerOptions{ID: container.ID, RemoveVolumes: true, Force: true}
-				if err := client.RemoveContainer(options); err != nil {
-					return err
+			} else {
+				if container.Image == image || inspection.Image == image || inspection.Config.Image == image {
+					logrus.Debugf("removing container: %s", container.ID)
+					options := docker.RemoveContainerOptions{ID: container.ID, RemoveVolumes: true, Force: true}
+					if err := client.RemoveContainer(options); err != nil {
+						return err
+					}
 				}
 			}
 		}
+
 		return nil
 	}
 }


### PR DESCRIPTION
Fixes #4 

I was able to replicate #4 by adding code into the `RemoveContainersOfImage` in `docker.go` that changed `container.ID` to one that would not be found. `client.InspectContainer` returned `nil` into the `inspection` var, and a `404` error, which we noticed, but then we went ahead and tried to use the `inspection` var, which was nil, and the panic happened.  

I tried a few scenarios to test this, including a container that committed suicide, but I couldn't get the timing right. 