### PR TITLE
Write Build Logs after `ci`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 vendor/*/
 
 test-reports/
+build_logs/

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ language: bash
 sudo: required
 
 env:
-  DOCKER_COMPOSE_VERSION: 1.8.1
-  DOCKER_VERSION: 1.11.2
-  LC_VERSION: 1.3.0
+  DOCKER_COMPOSE_VERSION: 1.9.0
+  DOCKER_VERSION: 1.12.6
+  LC_VERSION: 1.6.1
 
 before_install:
   # docker
@@ -13,7 +13,7 @@ before_install:
   - sudo bash -c "echo deb https://apt.dockerproject.org/repo ubuntu-precise main > /etc/apt/sources.list.d/docker.list"
   - sudo apt-get update
   - sudo apt-get purge lxc-docker
-  - sudo apt-get install docker-engine=${DOCKER_VERSION}-0~precise
+  - sudo apt-get install docker-engine=${DOCKER_VERSION}-0~ubuntu-precise
   # docker-compose
   - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
   - chmod +x docker-compose

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## Unreleased
 
+## v1.7.0
+
 - Fixed [https://github.com/cisco/elsy/issues/46](https://github.com/cisco/elsy/issues/46)).
+- Added support for dumping build logs
+(See [#43](https://github.com/cisco/elsy/issues/43)).
 
 ## v1.6.1
 

--- a/blackbox-test/features/blackbox-test.feature
+++ b/blackbox-test/features/blackbox-test.feature
@@ -1,11 +1,11 @@
 # Copyright 2016 Cisco Systems, Inc.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 # http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -90,7 +90,7 @@ Feature: blackbox-test task
     docker_image_name: elsyblackbox_docker_artifact_blackbox
     """
     When I run `lc blackbox-test --skip-package`
-    Then it should fail with 'image library/elsyblackbox_docker_artifact_blackbox not found'
+    Then it should fail with 'image library/elsyblackbox_docker_artifact_blackbox:latest not found'
     When I run `lc blackbox-test`
     Then it should succeed
     And the output should contain all of these:

--- a/blackbox-test/features/server/start.feature
+++ b/blackbox-test/features/server/start.feature
@@ -1,11 +1,11 @@
 # Copyright 2016 Cisco Systems, Inc.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 # http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -58,7 +58,7 @@ Feature: server start task
        - "80"
     """
     When I run `lc server start`
-    Then it should fail with 'image library/somefakeimagethatdoesntexist not found'
+    Then it should fail with 'image library/somefakeimagethatdoesntexist:latest not found'
 
   @teardown
   Scenario: starting prod server with no prodserver service defined

--- a/command/ci.go
+++ b/command/ci.go
@@ -17,6 +17,12 @@
 package command
 
 import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"sync"
+
 	"github.com/Sirupsen/logrus"
 	"github.com/cisco/elsy/helpers"
 	"github.com/codegangsta/cli"
@@ -24,7 +30,7 @@ import (
 
 // CmdCi runs ci loop
 func CmdCi(c *cli.Context) error {
-	defer CmdTeardown(c)
+	defer cleanup(c)
 
 	logrus.Info("Running bootstrap")
 	if err := CmdBootstrap(c); err != nil {
@@ -57,4 +63,73 @@ func CmdCi(c *cli.Context) error {
 		logrus.Info("No publish service defined, and no Dockerfile present.")
 		return nil
 	}
+}
+
+func cleanup(c *cli.Context) {
+	defer CmdTeardown(c)
+
+	//write build logs
+	logDir := c.String("build-logs-dir")
+	if len(logDir) > 0 {
+		logrus.WithFields(logrus.Fields{"build-logs-dir": logDir}).Info("writing build logs to build-logs-dir")
+
+		absDir, err := ensureLogDir(logDir)
+		if err != nil {
+			logrus.WithFields(logrus.Fields{
+				"build-logs-dir": logDir,
+				"error":          err,
+			}).Error("failure creating build-logs-dir, skipping writing logs")
+			return
+		}
+
+		// NOTE: we may want to filter these service logs and not write them iff
+		// the log just contains "Attaching to...", but that might be confusing to
+		// the user as well...so keeping it as simple as possible for now, just dump it all.
+		writeServiceLogs(absDir, helpers.DockerComposeServices())
+	}
+}
+
+func ensureLogDir(logDir string) (string, error) {
+	absDir, err := filepath.Abs(logDir)
+	if err != nil {
+		return "", fmt.Errorf("error taking abs path of build-logs-dir %v", err)
+	}
+
+	logrus.WithFields(logrus.Fields{"build-logs-dir": logDir}).Debug("wiping old logDir")
+	if err := os.RemoveAll(absDir); err != nil {
+		return "", fmt.Errorf("error removing old build-logs-dir %v", err)
+	}
+
+	logrus.WithFields(logrus.Fields{"build-logs-dir": logDir}).Debug("creating build-logs-dir")
+	if err := os.MkdirAll(absDir, os.FileMode(int(0766))); err != nil {
+		return "", fmt.Errorf("error creating build-logs-dir %v", err)
+	}
+
+	return absDir, nil
+}
+
+// writeServiceLogs assumes dir is the absolute path to write log files and
+// that it exists and is writable by current process
+func writeServiceLogs(dir string, services []string) {
+	var wg sync.WaitGroup
+	for _, s := range services {
+		wg.Add(1)
+		go func(service string) {
+			defer wg.Done()
+			p := filepath.Join(dir, service)
+
+			logs, err := helpers.ServiceLogs(service)
+			if err != nil {
+				logrus.WithFields(logrus.Fields{"service": service, "error": err}).Error("could not get logs for service")
+			}
+
+			logrus.WithFields(logrus.Fields{"service": service, "file": p}).Debug("writing logs for service")
+
+			if err := ioutil.WriteFile(p, logs, os.FileMode(int(0766))); err != nil {
+				logrus.WithFields(logrus.Fields{"service": service, "error": err}).Error("could not write logs for service")
+			}
+		}(s)
+	}
+
+	wg.Wait()
 }

--- a/docs/configuringlcrepo.md
+++ b/docs/configuringlcrepo.md
@@ -31,6 +31,8 @@ to use a custom docker-compose version for your repo.
 * `docker_registry`: address of docker registry to publish to.
 * `docker_registries`: takes a yaml sequence containing multiple registries to publish to. Use either
 `docker_registry` or `docker_registries`, not both.
+* `build_logs_dir`: If populated, elsy will dump ALL docker-compose service logs into this
+directory, directory must be relative to the repo root.
 
 Some configuration options may also be specified as command line arguments.
 If a command line argument is present, it will take precedence and override any

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -5,8 +5,8 @@ submit a patch to elsy, please submit a PR to the `master` branch.
 
 ## Local Development
 
-Use elsy to develop elsy! Currently docker 1.11 is required to run
-blackbox-tests.
+Use elsy to develop elsy! Currently docker 1.12.x and
+docker-compose 1.9.x is required to fully run blackbox-tests.
 
 This repo exposes all of the core elsy tasks for ongoing development:
 

--- a/helpers/docker-compose.go
+++ b/helpers/docker-compose.go
@@ -23,9 +23,10 @@ import (
 	"os/exec"
 	"strings"
 
+	yaml "gopkg.in/yaml.v2"
+
 	"github.com/Sirupsen/logrus"
 	"github.com/codegangsta/cli"
-	"gopkg.in/yaml.v2"
 )
 
 // ComposeFileVersion inside the repo
@@ -89,6 +90,16 @@ func GetDockerComposeVersion(c *cli.Context) (string, []int, error) {
 		return "", nil, err
 	}
 	return parseDockerComposeVersion(out)
+}
+
+// ServiceLogs simply returns the both stderr and stdout logs for a service
+func ServiceLogs(service string) ([]byte, error) {
+	cmd := DockerComposeCommand("logs", "--no-color", service)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 // GetComposeFileVersion of the current repo

--- a/lc.yml
+++ b/lc.yml
@@ -1,11 +1,11 @@
 # Copyright 2016 Cisco Systems, Inc.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 # http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -13,3 +13,4 @@
 # limitations under the License.
 
 project_name: elsy
+build_logs_dir: build_logs

--- a/main/commands.go
+++ b/main/commands.go
@@ -144,6 +144,11 @@ func Commands() []cli.Command {
 					Usage:  "Git commit that is being built",
 					EnvVar: "GIT_COMMIT",
 				},
+				cli.StringFlag{
+					Name:  "build-logs-dir",
+					Value: GetConfigFileString("build_logs_dir"),
+					Usage: "If populated, elsy will dump ALL docker-compose service logs into this directory, directory must be relative to the repo root.",
+				},
 			},
 		},
 		{


### PR DESCRIPTION
Best reviewed by reading commits one-by-one.

Implements #43 