### PR TITLE
Fixes issue #50

### DIFF
--- a/blackbox-test/features/server/start.feature
+++ b/blackbox-test/features/server/start.feature
@@ -58,7 +58,10 @@ Feature: server start task
        - "80"
     """
     When I run `lc server start`
-    Then it should fail with 'image library/somefakeimagethatdoesntexist:latest not found'
+    Then it should fail
+    And the output should contain one of the following:
+      |image library/somefakeimagethatdoesntexist:latest not found                        |
+      |repository somefakeimagethatdoesntexist not found: does not exist or no pull access|
 
   @teardown
   Scenario: starting prod server with no prodserver service defined

--- a/blackbox-test/steps/cli_steps.rb
+++ b/blackbox-test/steps/cli_steps.rb
@@ -1,11 +1,11 @@
 # Copyright 2016 Cisco Systems, Inc.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 # http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -39,6 +39,19 @@ end
 
 step "the output should not contain :expected" do |expected|
   expect(@output).not_to include(expected)
+end
+
+step "the output should contain one of the following:" do |table|
+  found = false
+
+  table.raw.flatten.each do |expected|
+    if @output.include? expected then
+      found = true
+      break
+    end
+  end
+
+  expect(found).to be(true), "the output should contain one of '#{table.raw.flatten}', but it did not. found: \n#{@output}"
 end
 
 step "the output should contain all of these:" do |table|

--- a/blackbox-test/steps/project_steps.rb
+++ b/blackbox-test/steps/project_steps.rb
@@ -1,11 +1,11 @@
 # Copyright 2016 Cisco Systems, Inc.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 # http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/blackbox-test/steps/server_steps.rb
+++ b/blackbox-test/steps/server_steps.rb
@@ -1,11 +1,11 @@
 # Copyright 2016 Cisco Systems, Inc.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 # http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -13,11 +13,5 @@
 # limitations under the License.
 
 step "it should report a correct address" do
-  ip = if RUBY_PLATFORM =~ /linux/
-    "127.0.0.1"
-  else
-    "172.17.8.101"
-  end
-
-  expect(@output).to match(%r{.*#{ip}.*}im)
+  expect(@output).to match(%r{.*127.0.0.1|172.17.8.101.*}im)
 end

--- a/helpers/docker.go
+++ b/helpers/docker.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"os"
 	"regexp"
-	"runtime"
 	"strconv"
 	"strings"
 
@@ -199,11 +198,10 @@ func DockerIp() (string, error) {
 		} else {
 			return "", fmt.Errorf("DOCKER_HOST environment variable is in the wrong format")
 		}
-	} else if runtime.GOOS == "linux" {
-		ip = "127.0.0.1"
 	} else {
-		return "", fmt.Errorf("Unable to determine Docker daemon IP")
+		ip = "127.0.0.1"
 	}
+
 	return ip, nil
 }
 


### PR DESCRIPTION
When using Docker for Mac, the server address will always be `127.0.0.1`. I also fixed a test that began failing with the latest DfM, involving the output when an image can't be pulled.