### PR TITLE
Build all the examples during bbtests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ script:
   - stty cols 200
   ## need to fix above docker-engine install to not require sudo
   - sudo lc ci
+  - sudo ./blackbox-test/build-examples.sh
 
 before_deploy:
   - sudo chown -R travis:travis target

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Fixed [issue #50](https://github.com/cisco/elsy/issues/50).
+- Fixed [issue #51](https://github.com/cisco/elsy/issues/51).
 
 ## v1.7.0
 

--- a/blackbox-test/build-examples.sh
+++ b/blackbox-test/build-examples.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+# This script is used for building all the example programs, when run from TravisCI.
+
+BBT_LC=$(pwd)/target/lc-blackbox
+DIR=$(pwd)/examples
+
+function build() {
+  dir=$1
+  has_tests=$2
+  has_bbtests=$3
+
+  echo "*** Building example: ${dir} ***"
+  cd $dir
+
+  if $has_tests; then
+    $BBT_LC bootstrap 
+  fi
+
+  if $has_bbtests; then
+    $BBT_LC blackbox-test 
+  fi
+} 
+
+set -e
+
+build "${DIR}/c-code" false true
+build "${DIR}/emberjs-ui" true true
+build "${DIR}/java-library" false false
+build "${DIR}/java-note-service" false true
+build "${DIR}/sbt-scala" false true
+build "${DIR}/simple-docker-image" false true
+
+


### PR DESCRIPTION
We need to know if the example programs build or not. This seems like a good way to know this. On my system, building all the examples took about seven minutes.