### PR TITLE
added upgrade 

### DIFF
--- a/blackbox-test/Dockerfile
+++ b/blackbox-test/Dockerfile
@@ -1,11 +1,11 @@
 # Copyright 2016 Cisco Systems, Inc.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 # http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,13 +15,15 @@
 FROM library/ruby:latest
 RUN apt-get update && \
     apt-get install -y \
-      netcat-openbsd && \
+      netcat-openbsd \
+      vim-common \
+      bsdmainutils && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
 RUN gem install \
-    turnip \
-    turnip_formatter \
+    turnip:2.1.1 \
+    turnip_formatter:0.5.0 \
     rspec_junit_formatter \
     byebug \
     rspec-instafail

--- a/blackbox-test/bin/patch-strings-in-binary
+++ b/blackbox-test/bin/patch-strings-in-binary
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+#
+# script from https://everydaywithlinux.blogspot.com/2012/11/patch-strings-in-binary-files-with-sed.html
+
+function patch_strings_in_file() {
+    local FILE="$1"
+    local PATTERN="$2"
+    local REPLACEMENT="$3"
+
+    # Find all unique strings in FILE that contain the pattern
+    STRINGS=$(strings ${FILE} | grep ${PATTERN} | sort -u -r)
+
+    if [ "${STRINGS}" != "" ] ; then
+        echo "File '${FILE}' contain strings with '${PATTERN}' in them:"
+
+        for OLD_STRING in ${STRINGS} ; do
+            # Create the new string with a simple bash-replacement
+            NEW_STRING=${OLD_STRING//${PATTERN}/${REPLACEMENT}}
+
+            # Create null terminated ASCII HEX representations of the strings
+            OLD_STRING_HEX="$(echo -n ${OLD_STRING} | xxd -g 0 -u -ps -c 256)00"
+            NEW_STRING_HEX="$(echo -n ${NEW_STRING} | xxd -g 0 -u -ps -c 256)00"
+
+            if [ ${#NEW_STRING_HEX} -le ${#OLD_STRING_HEX} ] ; then
+                # Pad the replacement string with null terminations so the
+                # length matches the original string
+                while [ ${#NEW_STRING_HEX} -lt ${#OLD_STRING_HEX} ] ; do
+                    NEW_STRING_HEX="${NEW_STRING_HEX}00"
+                done
+
+                # Now, replace every occurrence of OLD_STRING with NEW_STRING
+                echo -n "Replacing ${OLD_STRING} with ${NEW_STRING}... "
+                hexdump -ve '1/1 "%.2X"' ${FILE} | \
+                sed "s/${OLD_STRING_HEX}/${NEW_STRING_HEX}/g" | \
+                xxd -r -p > ${FILE}.tmp
+                chmod --reference ${FILE} ${FILE}.tmp
+                mv ${FILE}.tmp ${FILE}
+                echo "Done!"
+            else
+                echo "New string '${NEW_STRING}' is longer than old" \
+                     "string '${OLD_STRING}'. Skipping."
+            fi
+        done
+    fi
+}
+
+patch_strings_in_file $*

--- a/blackbox-test/features/system/upgrade.feature
+++ b/blackbox-test/features/system/upgrade.feature
@@ -1,0 +1,43 @@
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+Feature: system upgrade task
+  Scenario: try to upgrade snapshot build
+    When I run `lc system upgrade`
+    Then it should fail with "Upgrade not available on snapshot versions"
+
+  Scenario: upgrade a non-snapshot build
+    Given I run `mkdir -p /opt/bin`
+    And I run `cp /opt/project/target/lc-blackbox /opt/bin/lc-test`
+    And I run `chmod 755 /opt/bin/lc-test && ln -s /opt/bin/lc-test /opt/bin/lc`
+    And I run `/opt/project/blackbox-test/bin/patch-strings-in-binary /opt/bin/lc-test "$(/opt/bin/lc --version|awk '{print $3}')" "v1.9.9"`
+    When I run `/opt/bin/lc system upgrade`
+    Then it should succeed
+    And the output should contain all of these:
+        | Upgrading to |
+        | Done!        |
+        | 100.00%      |
+    When I run `/opt/bin/lc --version`
+    Then it should succeed
+    And the output should not contain "test"
+    Then I run `rm -rf /opt/bin`
+
+  Scenario: try to upgrade same version
+    Given I run `mkdir -p /opt/bin`
+    And I run `cp /opt/project/target/lc-blackbox /opt/bin/lc-test`
+    And I run `chmod 755 /opt/bin/lc-test && ln -s /opt/bin/lc-test /opt/bin/lc`
+    And I run `/opt/project/blackbox-test/bin/patch-strings-in-binary /opt/bin/lc-test "$(/opt/bin/lc --version|awk '{print $3}')" $(curl https://api.github.com/repos/cisco/elsy/releases/latest 2>/dev/null|grep tag_name|awk '{print $2}'|sed "s/\"\|,//g")`
+    When I run `/opt/bin/lc system upgrade`
+    Then it should succeed
+    And the output should contain "No new version available"

--- a/command/blackboxtest.go
+++ b/command/blackboxtest.go
@@ -17,9 +17,9 @@
 package command
 
 import (
-	"github.com/Sirupsen/logrus"
 	"github.com/cisco/elsy/helpers"
 	"github.com/codegangsta/cli"
+	"github.com/sirupsen/logrus"
 )
 
 // CmdBlackbox processes cmd args and then runs blackbox tests

--- a/command/ci.go
+++ b/command/ci.go
@@ -23,9 +23,9 @@ import (
 	"path/filepath"
 	"sync"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/cisco/elsy/helpers"
 	"github.com/codegangsta/cli"
+	"github.com/sirupsen/logrus"
 )
 
 // CmdCi runs ci loop

--- a/command/init.go
+++ b/command/init.go
@@ -24,8 +24,8 @@ import (
 	"strings"
 	"unicode"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/codegangsta/cli"
+	"github.com/sirupsen/logrus"
 )
 
 // markerFiles holds files that mark the repo as "already initialized"

--- a/command/install-dependencies.go
+++ b/command/install-dependencies.go
@@ -17,9 +17,9 @@
 package command
 
 import (
-	"github.com/Sirupsen/logrus"
 	"github.com/cisco/elsy/helpers"
 	"github.com/codegangsta/cli"
+	"github.com/sirupsen/logrus"
 )
 
 func CmdInstallDependencies(c *cli.Context) error {

--- a/command/package.go
+++ b/command/package.go
@@ -20,9 +20,9 @@ import (
 	"fmt"
 	"os/exec"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/cisco/elsy/helpers"
 	"github.com/codegangsta/cli"
+	"github.com/sirupsen/logrus"
 )
 
 // commitLabel identifies the git commit the image was built from

--- a/command/publish.go
+++ b/command/publish.go
@@ -22,9 +22,9 @@ import (
 	"os"
 	"os/exec"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/cisco/elsy/helpers"
 	"github.com/codegangsta/cli"
+	"github.com/sirupsen/logrus"
 )
 
 // CmdPublish will publish all artifacts associated with the current repo

--- a/command/release.go
+++ b/command/release.go
@@ -21,9 +21,9 @@ import (
 	"os/exec"
 
 	"errors"
-	"github.com/Sirupsen/logrus"
 	"github.com/cisco/elsy/helpers"
 	"github.com/codegangsta/cli"
+	"github.com/sirupsen/logrus"
 )
 
 // CmdRelease will create, and push a release tag

--- a/command/server/log.go
+++ b/command/server/log.go
@@ -19,9 +19,9 @@ package server
 import (
 	"fmt"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/cisco/elsy/helpers"
 	"github.com/codegangsta/cli"
+	"github.com/sirupsen/logrus"
 )
 
 func CmdLog(c *cli.Context) error {

--- a/command/server/start.go
+++ b/command/server/start.go
@@ -19,9 +19,9 @@ package server
 import (
 	"fmt"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/cisco/elsy/helpers"
 	"github.com/codegangsta/cli"
+	"github.com/sirupsen/logrus"
 )
 
 func CmdStart(c *cli.Context) error {

--- a/command/server/status.go
+++ b/command/server/status.go
@@ -19,10 +19,10 @@ package server
 import (
 	"fmt"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/cisco/elsy/helpers"
 	"github.com/codegangsta/cli"
 	"github.com/fatih/color"
+	"github.com/sirupsen/logrus"
 )
 
 func CmdStatus(c *cli.Context) error {

--- a/command/server/stop.go
+++ b/command/server/stop.go
@@ -17,9 +17,9 @@
 package server
 
 import (
-	"github.com/Sirupsen/logrus"
 	"github.com/cisco/elsy/helpers"
 	"github.com/codegangsta/cli"
+	"github.com/sirupsen/logrus"
 )
 
 func CmdStop(c *cli.Context) error {

--- a/command/system/upgrade.go
+++ b/command/system/upgrade.go
@@ -1,0 +1,185 @@
+/*
+ *  Copyright 2016 Cisco Systems, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package system
+
+import (
+	"errors"
+	"fmt"
+	"github.com/bitly/go-simplejson"
+	"github.com/blang/semver"
+	"github.com/cheggaaa/pb"
+	"github.com/cisco/elsy/helpers"
+	"github.com/codegangsta/cli"
+	"github.com/sirupsen/logrus"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+var (
+	releaseUrl        = "https://api.github.com/repos/cisco/elsy/releases/latest"
+	numberOfPlatforms = 2
+)
+
+type releaseInfo struct {
+	Name    string
+	Size    int
+	URL     string
+	TagName string
+}
+
+func CmdUpgrade(c *cli.Context) error {
+	currentVersion := strings.Trim(helpers.Version(), "\x00")
+
+	logrus.Infof("Current version: %s", currentVersion)
+	logrus.Info("Checking for newer version...")
+
+	if strings.Contains(currentVersion, "snapshot") {
+		return errors.New("Upgrade not available on snapshot versions")
+	}
+
+	cv, err := semver.Make(currentVersion[1:])
+	if err != nil {
+		return fmt.Errorf("error parsing current verison: %v", err)
+	}
+
+	info, err := getReleaseInfo()
+	if err != nil {
+		return err
+	}
+
+	availableVersion := info.TagName[1:]
+
+	av, err := semver.Make(availableVersion)
+	if err != nil {
+		return fmt.Errorf("error parsing available verison: %v", err)
+	}
+
+	if av.LTE(cv) {
+		logrus.Info("No new version available")
+		return nil
+	}
+
+	logrus.Infof("Upgrading to %s", info.TagName)
+
+	bar := pb.New(info.Size).SetUnits(pb.U_BYTES)
+	bar.Start()
+
+	resp, err := http.Get(info.URL)
+	if err != nil {
+		return err
+	}
+
+	defer resp.Body.Close()
+
+	dir, err := filepath.Abs(filepath.Dir(os.Args[0]))
+	if err != nil {
+		return fmt.Errorf("error getting installation directory: %v", err)
+	}
+
+	outfile := fmt.Sprintf("%s/%s", dir, info.Name)
+	writer, err := os.Create(outfile)
+	if err != nil {
+		return err
+	}
+
+	defer writer.Close()
+
+	multiWriter := io.MultiWriter(writer, bar)
+
+	bytesWritten, err := io.Copy(multiWriter, resp.Body)
+	if err != nil {
+		return err
+	}
+
+	if bytesWritten != int64(info.Size) {
+		return fmt.Errorf("incorrect byte count %v != %v", info.Size, bytesWritten)
+	}
+
+	bar.Finish()
+
+	lcPath := fmt.Sprintf("%s/%s", dir, filepath.Base(os.Args[0]))
+	lcWithVersionPath := fmt.Sprintf("%s/%s", dir, info.Name)
+	lcLinkName := fmt.Sprintf("%s/lc", dir)
+
+	err = os.Remove(lcPath)
+	if err != nil {
+		return err
+	}
+
+	err = os.Chmod(lcWithVersionPath, 0755)
+	if err != nil {
+		return err
+	}
+
+	err = os.Symlink(lcWithVersionPath, lcLinkName)
+	if err != nil {
+		return fmt.Errorf("Error symlinking lc: %v", err)
+	}
+
+	logrus.Info("Done!")
+	return nil
+}
+
+func getReleaseInfo() (*releaseInfo, error) {
+	resp, err := http.Get(releaseUrl)
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+
+	json, err := simplejson.NewFromReader(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	tagName, err := json.Get("tag_name").String()
+	if err != nil {
+		return nil, err
+	}
+
+	info := &releaseInfo{TagName: tagName}
+
+	assets := json.Get("assets")
+
+	currentOs := runtime.GOOS
+
+	for i := 0; i < numberOfPlatforms; i++ {
+		asset := assets.GetIndex(i)
+
+		info.Name, err = asset.Get("name").String()
+		if err != nil {
+			return nil, err
+		}
+
+		info.URL, err = asset.Get("browser_download_url").String()
+		if err != nil {
+			return nil, err
+		}
+
+		if strings.Contains(info.Name, currentOs) {
+			info.Size, err = asset.Get("size").Int()
+			return info, nil
+		}
+	}
+
+	return nil, errors.New("URL not found for OS")
+}

--- a/command/system/verify-install.go
+++ b/command/system/verify-install.go
@@ -23,9 +23,9 @@ import (
 	"os/exec"
 	"path/filepath"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/cisco/elsy/helpers"
 	"github.com/codegangsta/cli"
+	"github.com/sirupsen/logrus"
 )
 
 // file that we will use to verify volume mounts are working, assumption is that every lc repo should include this

--- a/command/teardown.go
+++ b/command/teardown.go
@@ -20,10 +20,10 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/cisco/elsy/helpers"
 	"github.com/codegangsta/cli"
 	"github.com/fsouza/go-dockerclient"
+	"github.com/sirupsen/logrus"
 )
 
 func CmdTeardown(c *cli.Context) error {

--- a/dev-env/lifecycle/package
+++ b/dev-env/lifecycle/package
@@ -22,7 +22,7 @@ rm -f ./target/lc*
 arch=amd64
 platforms=(darwin linux)
 build=`git rev-parse HEAD`
-version="snaphshot-$build"
+version="snapshot-$build"
 
 ## the authoritative regex for release tags is in ./helpers/git.go
 if [ -n "$GIT_TAG_NAME" ] && [[ "$GIT_TAG_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-.+)?$ ]]; then

--- a/helpers/command.go
+++ b/helpers/command.go
@@ -21,7 +21,7 @@ import (
 	"os"
 	"os/exec"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 func RunCommand(command *exec.Cmd) error {

--- a/helpers/docker-compose.go
+++ b/helpers/docker-compose.go
@@ -25,8 +25,8 @@ import (
 
 	yaml "gopkg.in/yaml.v2"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/codegangsta/cli"
+	"github.com/sirupsen/logrus"
 )
 
 // ComposeFileVersion inside the repo

--- a/helpers/docker.go
+++ b/helpers/docker.go
@@ -24,8 +24,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/fsouza/go-dockerclient"
+	"github.com/sirupsen/logrus"
 )
 
 // EnsureDockerConnectivity will return an error if the docker daemon is not accessible

--- a/main/commands.go
+++ b/main/commands.go
@@ -20,11 +20,11 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/cisco/elsy/command"
 	"github.com/cisco/elsy/command/server"
 	"github.com/cisco/elsy/command/system"
 	"github.com/codegangsta/cli"
+	"github.com/sirupsen/logrus"
 )
 
 // GlobalFlags sets up flags on the lc command proper
@@ -372,6 +372,12 @@ func Commands() []cli.Command {
 					Name:   "list-templates",
 					Usage:  "Displays the name of all available templates",
 					Action: panicOnError(system.CmdListTemplates),
+					Flags:  []cli.Flag{},
+				},
+				{
+					Name:   "upgrade",
+					Usage:  "Upgrades to the latest version",
+					Action: panicOnError(system.CmdUpgrade),
 					Flags:  []cli.Flag{},
 				},
 			},

--- a/main/main.go
+++ b/main/main.go
@@ -26,10 +26,10 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/cisco/elsy/helpers"
 	"github.com/cisco/elsy/template"
 	"github.com/codegangsta/cli"
+	"github.com/sirupsen/logrus"
 )
 
 func main() {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -3,10 +3,22 @@
 	"ignore": "test",
 	"package": [
 		{
-			"checksumSHA1": "QCAKzv0affIi7mlcGqPR8S3w6s0=",
-			"path": "github.com/Sirupsen/logrus",
-			"revision": "219c8cb75c258c552e999735be6df753ffc7afdc",
-			"revisionTime": "2016-02-24T21:10:30Z"
+			"checksumSHA1": "0EhLvZ6Og9HYqJtCc2Dzs1EgM30=",
+			"path": "github.com/bitly/go-simplejson",
+			"revision": "da1a8928f709389522c8023062a3739f3b4af419",
+			"revisionTime": "2017-02-06T15:46:32Z"
+		},
+		{
+			"checksumSHA1": "gntLgvUzJqZWf4NYxJr3p/3gcvk=",
+			"path": "github.com/blang/semver",
+			"revision": "4a1e882c79dcf4ec00d2e29fac74b9c8938d5052",
+			"revisionTime": "2017-02-02T18:38:21Z"
+		},
+		{
+			"checksumSHA1": "CmEZub5LMkcj2my3IwyntO9NhVM=",
+			"path": "github.com/cheggaaa/pb",
+			"revision": "9a180eb4617eb2112e01ca3fa25c61a6303afcaf",
+			"revisionTime": "2017-04-08T17:35:22Z"
 		},
 		{
 			"checksumSHA1": "i27YHcyHY4stkXm12/ztso3wHUo=",
@@ -23,12 +35,6 @@
 		{
 			"checksumSHA1": "rz0bI3Drq3xFCbrcG8mWwle7Qeg=",
 			"path": "github.com/fsouza/go-dockerclient",
-			"revision": "ddbe4ddacd876fa8f9202e656c1972124c4a665d",
-			"revisionTime": "2016-03-02T22:50:07Z"
-		},
-		{
-			"checksumSHA1": "7CvOHJK9x8GlFZmYe0nXMTz9teg=",
-			"path": "github.com/fsouza/go-dockerclient/external/github.com/Sirupsen/logrus",
 			"revision": "ddbe4ddacd876fa8f9202e656c1972124c4a665d",
 			"revisionTime": "2016-03-02T22:50:07Z"
 		},
@@ -117,6 +123,12 @@
 			"revisionTime": "2016-03-02T22:50:07Z"
 		},
 		{
+			"checksumSHA1": "EORrkaKJH6VDiwJhl0MkUSGrniw=",
+			"path": "github.com/fsouza/go-dockerclient/external/github.com/Sirupsen/logrus",
+			"revision": "ddbe4ddacd876fa8f9202e656c1972124c4a665d",
+			"revisionTime": "2016-03-02T22:50:07Z"
+		},
+		{
 			"checksumSHA1": "v9n1SOhjaR6eJd122dUWOfBDmN4=",
 			"path": "github.com/fsouza/go-dockerclient/external/golang.org/x/net/context",
 			"revision": "ddbe4ddacd876fa8f9202e656c1972124c4a665d",
@@ -141,6 +153,18 @@
 			"path": "github.com/mattn/go-isatty",
 			"revision": "4f7bcef27eec7925456d0c30c5e7b0408b3339be",
 			"revisionTime": "2016-02-24T22:11:55Z"
+		},
+		{
+			"checksumSHA1": "MNkKJyk2TazKMJYbal5wFHybpyA=",
+			"path": "github.com/mattn/go-runewidth",
+			"revision": "14207d285c6c197daabb5c9793d63e7af9ab2d50",
+			"revisionTime": "2017-02-01T02:35:40Z"
+		},
+		{
+			"checksumSHA1": "SvwRupGQyowCe8fHGW1syQDXdG8=",
+			"path": "github.com/sirupsen/logrus",
+			"revision": "219c8cb75c258c552e999735be6df753ffc7afdc",
+			"revisionTime": "2016-02-24T21:10:30Z"
 		},
 		{
 			"checksumSHA1": "+OgOXBoiQ+X+C2dsAeiOHwBIEH0=",


### PR DESCRIPTION
This PR does a few things, none of which were asked for, but I think needed doing.

1. When we use `lc` internally at Cisco, we have our own upgrade process. People outside Cisco don't, so I added `lc system upgrade` that will pull the latest release from Github and install it.
2. I changed the imports for `logrus` from `github.com/Sirupsen/logrus` to `github.com/sirupsen/logrus`. Glide and Dep, one of which we may be using instead of Govendor at some point, but puke on that. I've also seen Govendor get into a weird state because of the capital 'S'. 
3. We misspelled `snapshot` in `dev-env/lifecycle/package`.
4. I pegged the versions of turnip and turnip_formatter, because what we got without specifying a version doesn't actually work.

I had to do some really hinky things to test the various upgrade paths...