### PR TITLE
release v2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+## v2.1.0
+
+- Added `lc system upgrade` to fetch and install the latest verison of lc from Github.
+
 ## v2.0.0
 
 - Implemented [issue #64](https://github.com/cisco/elsy/issues/64).

--- a/README.md
+++ b/README.md
@@ -42,6 +42,14 @@ curl -fL -o /usr/local/bin/lc https://github.com/cisco/elsy/releases/download/v$
 chmod +x /usr/local/bin/lc
 ```
 
+As of version v2.1.0 of Elsy, you can upgrade to the latest verison by running 
+```
+lc system upgrade
+```
+
+Previous versions require repeating the installation steps to manually download and 
+install the binary.
+
 See the [Using elsy in a Project](docs/configuringlcrepo.md) document for
 info on how to setup a repo to use elsy.
 


### PR DESCRIPTION
Since I _always_ forget to update the CHANGELOG and the README... here those changes are, in a separate PR. I will release v2.1.0 from this commit, too.