### PR TITLE
add `resolve-docker-tag` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+## v2.3.0
+
+- add `resolve-docker-tag` command
+
 ## v2.2.0
 
 - `lc teardown` will now remove all networks created by the project.

--- a/blackbox-test/features/publish.feature
+++ b/blackbox-test/features/publish.feature
@@ -1,11 +1,11 @@
 # Copyright 2016 Cisco Systems, Inc.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 # http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -30,7 +30,7 @@ Feature: publish task
 
   Scenario: with an empty project, calling publish without the git branch
     When I run `lc publish`
-    Then it should fail with "The publish task requires that either a git branch or git tag be set"
+    Then it should fail with "expecting a git branch and/or a git tag be set, found neither"
 
   Scenario: with both docker_registry and docker_registries defined
     Given a file named "lc.yml" with:

--- a/blackbox-test/features/resolve-docker-tag.feature
+++ b/blackbox-test/features/resolve-docker-tag.feature
@@ -1,0 +1,38 @@
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+Feature: resolve-docker-tag task
+  Scenario: with an empty project, calling resolve-docker-tag without the git branch
+    When I run `lc resolve-docker-tag`
+    Then it should fail with "expecting a git branch and/or a git tag be set, found neither"
+
+  Scenario: calling resolve-docker-tag on the master branch
+    When I run `lc resolve-docker-tag --git-branch origin/master`
+    Then it should succeed with "latest"
+
+  Scenario: calling resolve-docker-tag on a release branch
+    When I run `lc resolve-docker-tag --git-branch origin/release/1.5`
+    Then it should succeed with "1.5"
+
+  Scenario: calling resolve-docker-tag on a feature branch
+    When I run `lc resolve-docker-tag --git-branch origin/fix-thing`
+    Then it should succeed with "snapshot.fix-thing"
+
+  Scenario: calling resolve-docker-tag on a tagged commit
+    When I run `lc resolve-docker-tag --git-tag v1.2.3`
+    Then it should succeed with "v1.2.3"
+
+  Scenario: calling resolve-docker-tag on a tagged master branch
+    When I run `lc resolve-docker-tag --git-tag v1.2.3 --git-branch=origin/master`
+    Then it should succeed with "v1.2.3"

--- a/command/resolve-docker-tag.go
+++ b/command/resolve-docker-tag.go
@@ -1,0 +1,34 @@
+/*
+ *  Copyright 2016 Cisco Systems, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package command
+
+import (
+	"fmt"
+
+	"github.com/cisco/elsy/helpers"
+	"github.com/codegangsta/cli"
+)
+
+// CmdResolveDockerTag outputs the docker tag which would be published given the current git tag and branch
+func CmdResolveDockerTag(c *cli.Context) error {
+	tagName, err := helpers.ExtractTag(c.String("git-tag"), c.String("git-branch"))
+	if err != nil {
+		return err
+	}
+	fmt.Println(tagName)
+	return nil
+}

--- a/helpers/git.go
+++ b/helpers/git.go
@@ -37,6 +37,20 @@ const (
 )
 
 /*
+*  extract tag name from git tag or git branch
+*  gives priority to git tag
+ */
+func ExtractTag(gitTag string, gitBranch string) (string, error) {
+	if len(gitTag) > 0 {
+		return ExtractTagFromTag(gitTag)
+	} else if len(gitBranch) > 0 {
+		return ExtractTagFromBranch(gitBranch)
+	} else {
+		return "", fmt.Errorf("expecting a git branch and/or a git tag be set, found neither")
+	}
+}
+
+/*
 *  extract tag name from branch
 *  branch: `master` becomes tag `latest`
 *  branch: `origin/release/xxx` becomes tag `xxx`

--- a/main/commands.go
+++ b/main/commands.go
@@ -258,6 +258,23 @@ func Commands() []cli.Command {
 			},
 		},
 		{
+			Name:   "resolve-docker-tag",
+			Usage:  "outputs the docker tag which would be published given a git tag and branch",
+			Action: panicOnError(command.CmdResolveDockerTag),
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:   "git-branch",
+					Usage:  "Git branch which is being published",
+					EnvVar: "GIT_BRANCH",
+				},
+				cli.StringFlag{
+					Name:   "git-tag",
+					Usage:  "Git tag which is being published",
+					EnvVar: "GIT_TAG_NAME",
+				},
+			},
+		},
+		{
 			Name:   "release",
 			Usage:  "Creates a release tag for the current repo",
 			Action: panicOnError(command.CmdRelease),


### PR DESCRIPTION
this command can be used to determine what docker tag `lc publish` will use. it is useful for post-processing actions after a successful `lc ci` such as a _deploy_ operation.