### PR TITLE
update build deps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ language: bash
 sudo: required
 
 env:
-  DOCKER_COMPOSE_VERSION: 1.9.0
+  DOCKER_COMPOSE_VERSION: 1.12.0
   DOCKER_VERSION: 1.12.6
-  LC_VERSION: 1.7.0
+  LC_VERSION: 2.3.0
 
 before_install:
   # docker

--- a/blackbox-test/Dockerfile
+++ b/blackbox-test/Dockerfile
@@ -28,11 +28,11 @@ RUN gem install \
     byebug \
     rspec-instafail
 
-ENV DOCKER_VERSION 1.11.2
+ENV DOCKER_VERSION 1.12.6
 RUN curl -L https://get.docker.com/builds/Linux/x86_64/docker-$DOCKER_VERSION.tgz | tar -xzvf - --strip-components=1 -C /usr/bin docker/docker
 RUN chmod a+x /usr/bin/docker
 
-ENV DOCKER_COMPOSE_VERSION 1.8.1
+ENV DOCKER_COMPOSE_VERSION 1.12.0
 RUN curl -Lo /usr/local/bin/docker-compose https://github.com/docker/compose/releases/download/$DOCKER_COMPOSE_VERSION/docker-compose-Linux-x86_64
 RUN chmod a+x /usr/local/bin/docker-compose
 


### PR DESCRIPTION
Continue to track coreos:stable release channel, so sticking with docker 1.12.6 for now.