### PR TITLE
stop trying to pull repo's docker-image artifact during bootstrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Unreleased
 
+- Improve `lc bootstrap` image pull logic so that elsy will never attempt to pull
+the image being packaged by the repo (i.e., the `docker-image-name` config). This
+means no more confusing error messages about "unable to pull image".
+- Start failing builds if images could not be pulled, this is now possible because
+we are no longer attempting to pull the repo's image (see above bullet).
 - Begin pulling images in parallel during `lc bootstrap` (requires `compose` 1.12.0 or higher).
 This can be disabled using the flag `disable-parallel-pull`.
 

--- a/blackbox-test/features/bootstrap.feature
+++ b/blackbox-test/features/bootstrap.feature
@@ -76,18 +76,20 @@ Feature: bootstrap task
     When I run `lc bootstrap`
     Then it should fail with "Service 'test' failed to build"
 
-  Scenario: with an image matching the docker artifact
+  Scenario: with an image matching the repo's docker artifact
     It is common to utilize the project's docker image artifact in a docker
     compose service. When docker-compose attempts to pull that service, it will
-    produce an error. In order to minimize developer confusion. That error
-    should be squelched while still showing errors where services pull images
-    which are not expected
+    produce an error. In order to minimize developer confusion elsy should not
+    attempt to pull any services using an image matching the repo's
+    docker-image-name config.
     Given a file named "docker-compose.yml" with:
     """yaml
     prodserver:
       image: baz
+    someotherserver:
+      image: baz
     other_service:
-      image: fdsafdsa
+      image: busybox
     """
     And a file named "lc.yml" with:
     """yaml
@@ -95,8 +97,7 @@ Feature: bootstrap task
     docker_image_name: baz
     """
     When I run `lc bootstrap`
-    Then it should fail pulling "fdsafdsa"
-    And it should not fail pulling "baz"
+    Then it should succeed
 
   Scenario: running in offline mode
     If we run with --offline, we should not try to pull any images.

--- a/blackbox-test/steps/docker_steps.rb
+++ b/blackbox-test/steps/docker_steps.rb
@@ -18,6 +18,12 @@ step "it :expectation fail pulling :image" do |expectation, image|
   ## starting with docker 1.10 the error message changed to remove the 'latest' from the image name
   ## so this regex tests for both
   expect(@output).send(meth, match(%r{image library/#{image}(:latest|) not found}))
+
+  if meth == :to
+    send "it should fail"
+  else
+    send "it should succeed"
+  end
 end
 
 step "the image :image should exist" do |image_name|

--- a/helpers/command.go
+++ b/helpers/command.go
@@ -17,7 +17,6 @@
 package helpers
 
 import (
-	"bufio"
 	"os"
 	"os/exec"
 
@@ -46,34 +45,6 @@ func RunCommandWithOutput(command *exec.Cmd) (string, error) {
 	}
 
 	return string(out[:]), err
-}
-
-type dropFilterFunc func(string) bool
-
-func RunCommandWithFilter(command *exec.Cmd, filter dropFilterFunc) error {
-	if pipe, err := command.StdoutPipe(); err != nil {
-		return err
-	} else {
-		go filterPipe(bufio.NewScanner(pipe), filter, os.Stdout)
-	}
-	if pipe, err := command.StderrPipe(); err != nil {
-		return err
-	} else {
-		go filterPipe(bufio.NewScanner(pipe), filter, os.Stderr)
-	}
-	logrus.Debugf("running command %s with args %v", command.Path, command.Args)
-	if err := command.Run(); err != nil {
-		return err
-	}
-	return nil
-}
-func filterPipe(scanner *bufio.Scanner, filter dropFilterFunc, dst *os.File) {
-	for scanner.Scan() {
-		if !filter(scanner.Text()) {
-			dst.Write(scanner.Bytes())
-			dst.WriteString("\n")
-		}
-	}
 }
 
 func ChainCommands(commands []*exec.Cmd) error {

--- a/helpers/docker-compose.go
+++ b/helpers/docker-compose.go
@@ -67,6 +67,7 @@ type DockerComposeV2 struct {
 	Networks DockerComposeNetworkMap
 }
 
+// DockerComposeServices returns all docker-compose services found inside the project
 func DockerComposeServices() (services []string) {
 	if _, err := os.Stat("docker-compose.yml"); err == nil {
 		for k := range getDockerComposeMap("docker-compose.yml") {
@@ -79,6 +80,26 @@ func DockerComposeServices() (services []string) {
 		}
 	}
 	return
+}
+
+// DockerComposeServicesExcluding same as DockerComposeServices(), but will exclude any services that has an image
+// declaration matching the 'image' argument.
+func DockerComposeServicesExcluding(image string) []string {
+	services := getDockerComposeMap("docker-compose.yml")
+	if file := os.Getenv("LC_BASE_COMPOSE_FILE"); len(file) > 0 {
+		for k, v := range getDockerComposeMap(file) {
+			if _, ok := services[k]; !ok {
+				services[k] = v
+			}
+		}
+	}
+	var filtered []string
+	for k, v := range services {
+		if v.Image != image {
+			filtered = append(filtered, k)
+		}
+	}
+	return filtered
 }
 
 // GetDockerComposeVersion returns version of the docker-compose binary


### PR DESCRIPTION
Fixes #78.

This refactors `CmdBootstrap` to filter down the services to pull by excluding any service using an `image:` declaration with the image from the repo's `docker-image-name`. This allows us to get rid of the brittle squelching of log messages by post-filtering the log stream. It also allows us to actualy fail `lc bootstrap` if images are not available, which is something that has caused confusion for a while.