### PR TITLE
Support Local Images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## v3.1.0
+
 - Add support for a `local_images` config in `lc.yml`. Images listed in this
 sequence will not be pulled during `lc bootstrap`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+- Add support for a `local_images` config in `lc.yml`. Images listed in this
+sequence will not be pulled during `lc bootstrap`.
+
 ## v3.0.0
 
 _Major version change because the exit code semantics around lc bootstrap have changed,

--- a/blackbox-test/features/bootstrap.feature
+++ b/blackbox-test/features/bootstrap.feature
@@ -99,6 +99,30 @@ Feature: bootstrap task
     When I run `lc bootstrap`
     Then it should succeed
 
+  Scenario: with local images
+    Sometimes a repo build assumes that a local docker image will be provided
+    by some external process. In these cases elsy should not attempt to pull
+    that image when running bootstrap. To support this use case repo owners
+    can use the local_images config in lc.yml to declare local images.
+    Given a file named "docker-compose.yml" with:
+    """yaml
+    prodserver:
+      image: baz
+    someotherserver:
+      image: bazlocal
+    other_service:
+      image: busybox
+    """
+    And a file named "lc.yml" with:
+    """yaml
+    name: testbootstrap
+    docker_image_name: baz
+    local_images:
+      - bazlocal
+    """
+    When I run `lc bootstrap`
+    Then it should succeed
+
   Scenario: running in offline mode
     If we run with --offline, we should not try to pull any images.
     Given a file named "docker-compose.yml" with:

--- a/blackbox-test/features/ci.feature
+++ b/blackbox-test/features/ci.feature
@@ -210,3 +210,23 @@ Feature: ci task
     When I run `lc --enable-scratch-volumes ci`
     Then it should succeed
     And the file "/test/foo.txt" should not exist
+
+  Scenario: local images should not get pulled
+    Given a file named "docker-compose.yml" with:
+    """yaml
+    prodserver:
+      image: baz
+    someotherserver:
+      image: bazlocal
+    other_service:
+      image: busybox
+    """
+    And a file named "lc.yml" with:
+    """yaml
+    name: testbootstrap
+    docker_image_name: baz
+    local_images:
+      - bazlocal
+    """
+    When I run `lc ci`
+    Then it should succeed

--- a/command/bootstrap.go
+++ b/command/bootstrap.go
@@ -38,9 +38,13 @@ func CmdBootstrap(c *cli.Context) error {
 			args = append(args, "pull", "--parallel")
 		}
 
-		if c.String("docker-image-name") != "" {
-			logrus.WithField("docker-image-name", c.String("docker-image-name")).Debug("not pulling services using repo's docker artifact")
-			args = append(args, helpers.DockerComposeServicesExcluding(c.String("docker-image-name"))...)
+		if c.String("docker-image-name") != "" || len(c.StringSlice("local-images")) > 0 {
+			excludes := c.StringSlice("local-images")
+			if c.String("docker-image-name") != "" {
+				excludes = append(excludes, c.String("docker-image-name"))
+			}
+			logrus.WithField("docker-image-name", excludes).Debug("not pulling services using repo's docker artifact")
+			args = append(args, helpers.DockerComposeServicesExcluding(excludes)...)
 		}
 
 		pullCmd := helpers.DockerComposeCommand(args...)

--- a/docs/configuringlcrepo.md
+++ b/docs/configuringlcrepo.md
@@ -33,6 +33,10 @@ to use a custom docker-compose version for your repo.
 `docker_registry` or `docker_registries`, not both.
 * `build_logs_dir`: If populated, elsy will dump ALL docker-compose service logs into this
 directory, directory must be relative to the repo root.
+* `local_images`: takes a yaml sequence containing images to not pull during
+bootstrap. This allows repo owners to provide images to the build using some
+external process. The image declared in `docker_image_name` is automatically
+included in this sequence.
 
 Some configuration options may also be specified as command line arguments.
 If a command line argument is present, it will take precedence and override any

--- a/helpers/docker-compose.go
+++ b/helpers/docker-compose.go
@@ -83,8 +83,8 @@ func DockerComposeServices() (services []string) {
 }
 
 // DockerComposeServicesExcluding same as DockerComposeServices(), but will exclude any services that has an image
-// declaration matching the 'image' argument.
-func DockerComposeServicesExcluding(image string) []string {
+// declaration in the 'excluded' slice.
+func DockerComposeServicesExcluding(excluded []string) []string {
 	services := getDockerComposeMap("docker-compose.yml")
 	if file := os.Getenv("LC_BASE_COMPOSE_FILE"); len(file) > 0 {
 		for k, v := range getDockerComposeMap(file) {
@@ -94,9 +94,15 @@ func DockerComposeServicesExcluding(image string) []string {
 		}
 	}
 	var filtered []string
-	for k, v := range services {
-		if v.Image != image {
-			filtered = append(filtered, k)
+	for service, image := range services {
+		var exclude bool
+		for _, i := range excluded {
+			if image.Image == i {
+				exclude = true
+			}
+		}
+		if !exclude {
+			filtered = append(filtered, service)
 		}
 	}
 	return filtered

--- a/main/commands.go
+++ b/main/commands.go
@@ -88,6 +88,11 @@ func Commands() []cli.Command {
 					Value: GetConfigFileString("docker_image_name"),
 					Usage: "local docker image name to publish",
 				},
+				cli.StringSliceFlag{
+					Name:  "local-images",
+					Value: resolveLocalImagesFromConfig(),
+					Usage: "images to exclude from pulling",
+				},
 			},
 		},
 		{
@@ -128,6 +133,11 @@ func Commands() []cli.Command {
 					Name:  "docker-image-name",
 					Value: GetConfigFileString("docker_image_name"),
 					Usage: "local docker image name to publish",
+				},
+				cli.StringSliceFlag{
+					Name:  "local-images",
+					Value: resolveLocalImagesFromConfig(),
+					Usage: "images to exclude from pulling",
 				},
 				cli.StringSliceFlag{
 					Name:  "docker-registry",
@@ -463,5 +473,19 @@ func resolveDockerRegistryFromConfig() *cli.StringSlice {
 		return &v
 	}
 
+	return &cli.StringSlice{}
+}
+
+func resolveLocalImagesFromConfig() *cli.StringSlice {
+	seqK := "local_images"
+	if IsKeyInConfig(seqK) {
+		v := cli.StringSlice(GetConfigFileSlice(seqK))
+		if len(v) == 0 {
+			// this will happen if the yaml containing the sequence is not perfectly formatted (e.g., if '-value' instead of '- value')
+			// eventually we need to make our parsing logic more forgiving, but until then just make it crystal clear when we can't parse something.
+			panic(fmt.Errorf("Error parsing 'lc.yml': found %q key, but did not find any images, verify that yaml is correct", seqK))
+		}
+		return &v
+	}
 	return &cli.StringSlice{}
 }


### PR DESCRIPTION
Add support for `local_images` config in lc.yml

Images listed in this sequence will not be pulled during `lc bootstrap`. This is required because https://github.com/cisco/elsy/pull/82 introduced more strict checking on the pulling of images, and it turns out some builds provide images outside of the scope of elsy.