### PR TITLE
use elsy v3.1.0 in build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ sudo: required
 env:
   DOCKER_COMPOSE_VERSION: 1.16.1
   DOCKER_VERSION: 1.12.6
-  LC_VERSION: 2.3.0
+  LC_VERSION: 3.1.0
 
 before_install:
   # docker


### PR DESCRIPTION
requires #84 to be merged and released first.

## Tasks
- [x] release v3.1.0