### PR TITLE
Build with golang 1.15

### DIFF
--- a/dev-env/Dockerfile
+++ b/dev-env/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM library/golang:1.10
+FROM library/golang:1.15
 RUN GOOS=darwin GOARCH=amd64 go install -v std
 
 RUN go get -u github.com/kardianos/govendor

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -51,7 +51,7 @@
 			"revisionTime": "2016-03-02T22:50:07Z"
 		},
 		{
-			"checksumSHA1": "OECIN3MgL6Q/bup7ZbPYjAbPLZs=",
+			"checksumSHA1": "SNLOCk/XcRh0kfrx3rUT1kyq6aY=",
 			"path": "github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/archive",
 			"revision": "ddbe4ddacd876fa8f9202e656c1972124c4a665d",
 			"revisionTime": "2016-03-02T22:50:07Z"
@@ -135,7 +135,7 @@
 			"revisionTime": "2016-03-02T22:50:07Z"
 		},
 		{
-			"checksumSHA1": "hugdbffSP0G67FyJUhGvu9O0WmM=",
+			"checksumSHA1": "g3YF/iwTLxB/2aW+MZitfLGNdTU=",
 			"path": "github.com/fsouza/go-dockerclient/external/golang.org/x/sys/unix",
 			"revision": "ddbe4ddacd876fa8f9202e656c1972124c4a665d",
 			"revisionTime": "2016-03-02T22:50:07Z"


### PR DESCRIPTION
The current 1.10 go binary crashes on macOS 12 Monterey. See https://github.com/golang/go/wiki/MacOS12BSDThreadRegisterIssue

Starting from golang 1.16, the build fails due to go complaining about `go: cannot find main module, but found vendor/vendor.json in /go/src/github.com/cisco/elsy`. I don't have time to spend on this so this PR bumps it to golang 1.15 only, which is sufficient to solve the original issue with Monterey.